### PR TITLE
feat: implement Figma V2 UI overhaul

### DIFF
--- a/TASK_V2.md
+++ b/TASK_V2.md
@@ -1,0 +1,700 @@
+# Polyscan V2 — Figma UI Overhaul Task
+
+## Branch
+`feat/issue-7-figma-v2-ui-overhaul`
+
+## Figma References
+- File: https://www.figma.com/design/8pauNIpxMvNjWWzR3fNIkk/Untitled
+- Node 1:1318 = desktop full layout
+- Node 1:1762 = component detail
+
+---
+
+## STEP 1: Update tailwind.config.js
+
+Replace color tokens with Figma V2 palette:
+
+```js
+export default {
+  content: ["./index.html","./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        /* Backgrounds */
+        "bg-base":        "#0e0d14",
+        "bg-card":        "#22202e",
+        "bg-card-inner":  "#1a1826",
+        "bg-sidebar":     "#13121e",
+
+        /* Primary */
+        "primary":        "#33ff99",
+        "primary-hover":  "#00ccc9",
+        "on-primary":     "#000000",
+
+        /* Filter active */
+        "filter-active":  "#e566ff",
+        "on-filter":      "#000000",
+
+        /* Text */
+        "text-primary":   "#ffffff",
+        "text-secondary": "#c0c0c0",
+        "text-muted":     "#6b6882",
+
+        /* Badges */
+        "under-bg":       "#0d2218",
+        "under-text":     "#00fd87",
+        "over-bg":        "#2a1212",
+        "over-text":      "#ff5f52",
+
+        /* Borders */
+        "border-default": "#2e2c3e",
+        "border-subtle":  "#1e1d2b",
+
+        /* Legacy compat */
+        "surface":           "#0e0d14",
+        "surface-dim":       "#13121e",
+        "surface-low":       "#22202e",
+        "surface-container": "#1a1826",
+        "surface-high":      "#2e2c3e",
+        "surface-highest":   "#3a3850",
+        "on-surface":        "#ffffff",
+        "on-surface-variant":"#c0c0c0",
+        "outline":           "#6b6882",
+        "outline-variant":   "#2e2c3e",
+        "primary-fixed":     "#33ff99",
+        "primary-dim":       "#00ccc9",
+        "secondary":         "#ff5f52",
+        "secondary-container":"#2a1212",
+      },
+      fontFamily: {
+        mono: ['"JetBrains Mono"', 'monospace'],
+        sg:   ['"Space Grotesk"', 'sans-serif'],
+        body: ['Inter', 'sans-serif'],
+      },
+      borderRadius: {
+        DEFAULT: "6px",
+        sm: "4px",
+        lg: "8px",
+        full: "9999px",
+        none: "0px",
+      },
+    },
+  },
+  plugins: [],
+}
+```
+
+---
+
+## STEP 2: Update src/index.css
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+* { box-sizing: border-box; }
+body {
+  background-color: #0e0d14;
+  color: #ffffff;
+  font-family: "Inter", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  margin: 0;
+}
+.material-symbols-outlined {
+  font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+  display: inline-block;
+  line-height: 1;
+}
+::-webkit-scrollbar { width: 4px; height: 4px; }
+::-webkit-scrollbar-track { background: #0e0d14; }
+::-webkit-scrollbar-thumb { background: #2e2c3e; }
+```
+
+---
+
+## STEP 3: Create src/components/SignalCard.tsx (NEW component)
+
+```tsx
+import type { GapResult } from "../types"
+
+interface Props {
+  result: GapResult
+}
+
+export function SignalCard({ result }: Props) {
+  const isUnder = result.direction === "UNDER"
+  const gapPct = (result.gap * 100).toFixed(2)
+  const netProfit = (result.gap - 0.04).toFixed(3) // after ~2% fee each side
+
+  // Sparkline bars — 6 bars with varying heights
+  const sparkBars = [0.3, 0.6, 0.45, 0.8, 0.55, 1.0]
+
+  return (
+    <div
+      className="bg-bg-card border border-border-default rounded-sm p-4 cursor-pointer hover:border-border-subtle transition-colors space-y-3"
+      onClick={() => window.open(`https://polymarket.com/event/${result.slug}`, "_blank")}
+    >
+      {/* Header: question + direction badge */}
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-text-primary text-xs font-body leading-snug line-clamp-2 flex-1">
+          {result.question}
+        </p>
+        <span className={`shrink-0 inline-block px-2 py-0.5 text-[9px] font-mono font-bold uppercase rounded-sm ${
+          isUnder
+            ? "bg-under-bg text-under-text"
+            : result.direction === "OVER"
+            ? "bg-over-bg text-over-text"
+            : "bg-surface-high text-text-muted"
+        }`}>
+          {result.direction}
+        </span>
+      </div>
+
+      {/* Sparkline */}
+      <div className="flex items-end gap-0.5 h-6">
+        {sparkBars.map((h, i) => (
+          <div
+            key={i}
+            className="flex-1 rounded-none"
+            style={{
+              height: `${h * 100}%`,
+              background: isUnder
+                ? `rgba(0,253,135,${0.3 + h * 0.6})`
+                : `rgba(255,95,82,${0.3 + h * 0.6})`,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* YES / NO / SUM boxes */}
+      <div className="grid grid-cols-3 gap-1">
+        {[
+          { label: "YES", value: result.yes.toFixed(3) },
+          { label: "NO",  value: result.no.toFixed(3) },
+          { label: "SUM", value: result.sum.toFixed(3) },
+        ].map(({ label, value }) => (
+          <div key={label} className="bg-bg-card-inner border border-border-subtle rounded-sm p-2 text-center">
+            <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">{label}</div>
+            <div className="text-xs font-mono text-text-primary">{value}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Gap % large */}
+      <div className="flex items-end justify-between">
+        <div>
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">GAP</div>
+          <div
+            className="font-mono font-bold leading-none"
+            style={{ fontSize: "44px", color: isUnder ? "#00fd87" : "#ff5f52" }}
+          >
+            {isUnder ? "-" : "+"}{gapPct}%
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">NET PROFIT</div>
+          <div className={`text-sm font-mono font-bold ${Number(netProfit) > 0 ? "text-under-text" : "text-over-text"}`}>
+            {Number(netProfit) > 0 ? "+" : ""}{netProfit}
+          </div>
+        </div>
+      </div>
+
+      {/* Gap bar gradient */}
+      <div className="h-1 w-full bg-border-default rounded-full overflow-hidden">
+        <div
+          className="h-full rounded-full"
+          style={{
+            width: `${Math.min(result.gap * 1000, 100)}%`,
+            background: isUnder
+              ? "linear-gradient(90deg, #00fd87, #00ccc9)"
+              : "linear-gradient(90deg, #ff5f52, #e566ff)",
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+## STEP 4: Update src/components/StatsBar.tsx
+
+```tsx
+interface Props {
+  totalScanned: number
+  found: number
+  lastScanAt: Date | null
+  isScanning: boolean
+}
+
+export function StatsBar({ totalScanned, found, lastScanAt, isScanning }: Props) {
+  const timeStr = lastScanAt
+    ? lastScanAt.toUTCString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, "$1") + " UTC"
+    : "—"
+
+  return (
+    <div className="space-y-2">
+      {/* Session stats */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="bg-bg-card border border-border-default rounded-sm p-3">
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-1">Scanned</div>
+          <div className="text-xl font-mono font-bold text-text-primary">{totalScanned.toLocaleString()}</div>
+        </div>
+        <div className="bg-bg-card border border-border-default rounded-sm p-3">
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-1">Signals</div>
+          <div className="text-xl font-mono font-bold text-primary">{String(found).padStart(2, "0")}</div>
+        </div>
+      </div>
+
+      {/* Live indicator */}
+      <div className="flex items-center justify-between px-1">
+        <div className="flex items-center gap-1.5">
+          <div className={`w-1.5 h-1.5 rounded-full ${isScanning ? "bg-primary animate-pulse" : "bg-text-muted"}`} />
+          <span className="text-[9px] font-mono text-text-muted uppercase">
+            {isScanning ? "SCANNING" : lastScanAt ? "LAST: " + timeStr : "IDLE"}
+          </span>
+        </div>
+        <span className="text-[9px] font-mono text-primary">14MS</span>
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+## STEP 5: Update src/components/FilterBar.tsx
+
+```tsx
+import type { FilterDirection } from "../types"
+
+interface Props {
+  minGap: number
+  direction: FilterDirection
+  onMinGapChange: (v: number) => void
+  onDirectionChange: (d: FilterDirection) => void
+}
+
+export function FilterBar({ minGap, direction, onMinGapChange, onDirectionChange }: Props) {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-[9px] font-mono text-text-muted uppercase tracking-widest">Filters</h3>
+
+      {/* Min gap slider */}
+      <div className="space-y-2">
+        <div className="flex justify-between text-[9px] font-mono">
+          <span className="text-text-muted uppercase">Min Gap</span>
+          <span className="text-primary">{(minGap * 100).toFixed(0)}¢</span>
+        </div>
+        <input
+          type="range" min="1" max="20" value={Math.round(minGap * 100)}
+          onChange={e => onMinGapChange(Number(e.target.value) / 100)}
+          className="w-full h-0.5 bg-border-default appearance-none cursor-pointer accent-[#33ff99]"
+        />
+      </div>
+
+      {/* Direction toggle */}
+      <div className="flex gap-1">
+        {(["ALL","OVER","UNDER"] as FilterDirection[]).map(d => (
+          <button
+            key={d}
+            onClick={() => onDirectionChange(d)}
+            className={`flex-1 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm transition-colors ${
+              direction === d
+                ? "bg-filter-active text-on-filter"
+                : "bg-bg-card border border-border-default text-text-muted hover:text-[#c0c0c0]"
+            }`}
+          >{d}</button>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+## STEP 6: Update src/components/GapBarChart.tsx
+
+```tsx
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts"
+import type { GapResult } from "../types"
+
+interface Props { results: GapResult[] }
+
+export function GapBarChart({ results }: Props) {
+  const data = results.slice(0, 20).map(r => ({
+    name: r.question.slice(0, 18) + "…",
+    gap: parseFloat((r.gap * 100).toFixed(2)),
+    direction: r.direction,
+  }))
+
+  if (data.length === 0) return (
+    <div className="bg-bg-card border border-border-default rounded-sm p-6 flex items-center justify-center h-40">
+      <span className="text-text-muted font-mono text-xs uppercase">No signals — run scan</span>
+    </div>
+  )
+
+  return (
+    <div className="bg-bg-card border border-border-default rounded-sm p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-[9px] font-mono text-text-muted uppercase tracking-widest">Gap Distribution</h3>
+        <div className="flex gap-3 text-[8px] font-mono">
+          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none" style={{background:"#33ff99"}}></span>UNDER</span>
+          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none" style={{background:"#ff5f52"}}></span>OVER</span>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={140}>
+        <BarChart data={data} barCategoryGap="20%">
+          <XAxis dataKey="name" tick={false} axisLine={false} tickLine={false} />
+          <YAxis
+            tick={{ fill:"#6b6882", fontSize:9, fontFamily:"JetBrains Mono" }}
+            axisLine={false} tickLine={false} unit="¢"
+          />
+          <Tooltip
+            contentStyle={{ background:"#22202e", border:"1px solid #2e2c3e", borderRadius:"6px", fontSize:10, fontFamily:"JetBrains Mono" }}
+            labelStyle={{ color:"#c0c0c0" }}
+            formatter={(v: number) => [`${v}¢`, "Gap"]}
+          />
+          <Bar dataKey="gap" radius={[2,2,0,0]}>
+            {data.map((entry, i) => (
+              <Cell key={i} fill={entry.direction === "UNDER" ? "#33ff99" : "#ff5f52"} opacity={0.85} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+```
+
+---
+
+## STEP 7: Update src/components/ResultTable.tsx
+
+Keep existing logic but update colors to V2 tokens:
+- Table bg: `bg-bg-card`
+- Row alt: `bg-bg-card` / `bg-bg-card-inner`
+- Header: `bg-bg-card-inner`
+- Border: `border-border-default`
+- UNDER badge: `bg-under-bg text-under-text`
+- OVER badge: `bg-over-bg text-over-text`
+- Gap UNDER: `text-under-text`
+- Gap OVER: `text-over-text`
+- Hover: `hover:bg-surface-high`
+
+Rewrite the full component with these tokens applied.
+
+---
+
+## STEP 8: Update src/components/ScannerPage.tsx
+
+Change layout to card grid:
+
+```tsx
+import { useState } from "react"
+import { useScan } from "../hooks/useScan"
+import { StatsBar } from "./StatsBar"
+import { FilterBar } from "./FilterBar"
+import { GapBarChart } from "./GapBarChart"
+import { ResultTable } from "./ResultTable"
+import { SignalCard } from "./SignalCard"
+import type { FilterDirection } from "../types"
+
+export function ScannerPage() {
+  const [minGap, setMinGap] = useState(0.03)
+  const [direction, setDirection] = useState<FilterDirection>("ALL")
+  const [view, setView] = useState<"cards" | "table">("cards")
+  const { results, isScanning, lastScanAt, totalScanned, error, scan } = useScan(minGap)
+  const filtered = results.filter(r => direction === "ALL" ? true : r.direction === direction)
+
+  return (
+    <div className="p-4 lg:p-6 space-y-4">
+      {error && (
+        <div className="bg-over-bg border border-over-text/30 p-3 text-over-text font-mono text-xs rounded-sm">
+          ⚠ {error}
+        </div>
+      )}
+
+      {/* Chart */}
+      <GapBarChart results={filtered} />
+
+      {/* View toggle + count */}
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] font-mono text-text-muted uppercase">
+          {filtered.length} signals
+        </span>
+        <div className="flex gap-1">
+          <button
+            onClick={() => setView("cards")}
+            className={`px-3 py-1 text-[9px] font-mono uppercase rounded-sm transition-colors ${
+              view === "cards" ? "bg-primary text-on-primary" : "bg-bg-card border border-border-default text-text-muted hover:text-text-primary"
+            }`}
+          >Cards</button>
+          <button
+            onClick={() => setView("table")}
+            className={`px-3 py-1 text-[9px] font-mono uppercase rounded-sm transition-colors ${
+              view === "table" ? "bg-primary text-on-primary" : "bg-bg-card border border-border-default text-text-muted hover:text-text-primary"
+            }`}
+          >Table</button>
+        </div>
+      </div>
+
+      {/* Content */}
+      {view === "cards" ? (
+        filtered.length === 0 ? (
+          <div className="bg-bg-card border border-border-default rounded-sm p-8 text-center">
+            <p className="text-text-muted font-mono text-xs uppercase">No signals found — try lowering threshold or run a scan</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+            {filtered.map((r, i) => <SignalCard key={i} result={r} />)}
+          </div>
+        )
+      ) : (
+        <ResultTable results={filtered} />
+      )}
+    </div>
+  )
+}
+```
+
+---
+
+## STEP 9: Update src/App.tsx
+
+Full rewrite with V2 sidebar layout:
+
+```tsx
+import { useState } from "react"
+import { ScannerPage } from "./components/ScannerPage"
+import { StatsBar } from "./components/StatsBar"
+import { FilterBar } from "./components/FilterBar"
+import { useScan } from "./hooks/useScan"
+import type { FilterDirection } from "./types"
+
+type NavItem = "terminal" | "history" | "settings"
+
+const navItems = [
+  { id: "terminal" as NavItem, icon: "terminal", label: "TERMINAL" },
+  { id: "history" as NavItem, icon: "history", label: "HISTORY" },
+  { id: "settings" as NavItem, icon: "settings", label: "SETTINGS" },
+]
+
+export default function App() {
+  const [active, setActive] = useState<NavItem>("terminal")
+  const [minGap, setMinGap] = useState(0.03)
+  const [direction, setDirection] = useState<FilterDirection>("ALL")
+  const { results, isScanning, lastScanAt, totalScanned, error, scan } = useScan(minGap)
+  const filtered = results.filter(r => direction === "ALL" ? true : r.direction === direction)
+
+  return (
+    <div className="min-h-screen bg-bg-base text-text-primary flex flex-col">
+
+      {/* Desktop layout */}
+      <div className="hidden lg:flex flex-1">
+
+        {/* Sidebar 240px */}
+        <aside className="w-60 flex-shrink-0 bg-bg-sidebar border-r border-border-default flex flex-col fixed top-0 left-0 h-full z-40">
+          {/* Brand */}
+          <div className="px-5 py-5 border-b border-border-default">
+            <div className="flex items-center gap-2">
+              <span className="material-symbols-outlined text-primary text-lg">terminal</span>
+              <span className="font-mono font-bold text-primary tracking-widest text-sm uppercase">POLYSCAN</span>
+            </div>
+            <div className="text-[9px] font-mono text-text-muted mt-1">v1.0.0 · Arbitrage Scanner</div>
+          </div>
+
+          {/* Nav */}
+          <nav className="py-2">
+            {navItems.map(item => (
+              <button key={item.id} onClick={() => setActive(item.id)}
+                className={`w-full flex items-center gap-3 px-5 py-2.5 text-xs font-mono uppercase transition-colors ${
+                  active === item.id
+                    ? "text-primary border-r-2 border-primary bg-bg-card"
+                    : "text-text-muted hover:text-text-primary"
+                }`}>
+                <span className="material-symbols-outlined text-base">{item.icon}</span>
+                {item.label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="flex-1" />
+
+          {/* Stats + Filter in sidebar */}
+          <div className="px-4 pb-4 space-y-5 border-t border-border-default pt-4">
+            <StatsBar
+              totalScanned={totalScanned}
+              found={filtered.length}
+              lastScanAt={lastScanAt}
+              isScanning={isScanning}
+            />
+            <FilterBar
+              minGap={minGap}
+              direction={direction}
+              onMinGapChange={setMinGap}
+              onDirectionChange={setDirection}
+            />
+          </div>
+        </aside>
+
+        {/* Main content */}
+        <main className="ml-60 flex-1 flex flex-col min-h-screen">
+          {/* Top bar */}
+          <header className="flex items-center justify-between px-6 h-12 bg-bg-sidebar border-b border-border-default sticky top-0 z-30">
+            <div className="flex items-center gap-6">
+              <span className="text-[10px] font-mono text-text-muted uppercase tracking-widest">TERMINAL_CORE</span>
+              <button className="text-[10px] font-mono text-primary border-b border-primary pb-0.5">Live Arbitrage Feed</button>
+            </div>
+            <div className="flex items-center gap-3">
+              {lastScanAt && (
+                <span className="text-[9px] font-mono text-text-muted">
+                  {lastScanAt.toUTCString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, "$1")} UTC
+                </span>
+              )}
+              <button
+                onClick={scan}
+                disabled={isScanning}
+                className="px-4 py-1.5 text-xs font-mono font-bold uppercase rounded-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  background: "#33ff99",
+                  color: "#000",
+                }}
+                onMouseEnter={e => { if (!isScanning) (e.target as HTMLElement).style.background = "#00ccc9" }}
+                onMouseLeave={e => { (e.target as HTMLElement).style.background = "#33ff99" }}
+              >
+                {isScanning ? "SCANNING…" : "SCAN NOW"}
+              </button>
+            </div>
+          </header>
+
+          {/* Page */}
+          {active === "terminal" && <ScannerPage />}
+          {active !== "terminal" && (
+            <div className="flex-1 flex items-center justify-center">
+              <span className="font-mono text-text-muted text-sm uppercase">Coming Soon — {active}</span>
+            </div>
+          )}
+        </main>
+      </div>
+
+      {/* Mobile layout */}
+      <div className="lg:hidden flex flex-col flex-1">
+        {/* Mobile header */}
+        <header className="flex items-center justify-between px-4 h-12 bg-bg-sidebar border-b border-border-default sticky top-0 z-30">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary">terminal</span>
+            <span className="font-mono font-bold text-primary tracking-widest text-sm uppercase">POLYSCAN</span>
+          </div>
+          <button
+            onClick={scan}
+            disabled={isScanning}
+            className="px-3 py-1.5 text-xs font-mono font-bold uppercase rounded-sm disabled:opacity-50"
+            style={{ background: "#33ff99", color: "#000" }}
+          >
+            {isScanning ? "…" : "SCAN"}
+          </button>
+        </header>
+
+        {/* Mobile stats */}
+        <div className="px-4 pt-4 pb-2">
+          <StatsBar totalScanned={totalScanned} found={filtered.length} lastScanAt={lastScanAt} isScanning={isScanning} />
+        </div>
+        <div className="px-4 pb-4">
+          <FilterBar minGap={minGap} direction={direction} onMinGapChange={setMinGap} onDirectionChange={setDirection} />
+        </div>
+
+        {/* Mobile content */}
+        <main className="flex-1 pb-16">
+          {active === "terminal" && <ScannerPage />}
+        </main>
+
+        {/* Mobile bottom nav */}
+        <nav className="fixed bottom-0 left-0 right-0 flex bg-bg-sidebar border-t border-border-default z-40">
+          {navItems.map(item => (
+            <button key={item.id} onClick={() => setActive(item.id)}
+              className={`flex-1 flex flex-col items-center justify-center py-3 transition-colors ${
+                active === item.id ? "text-primary" : "text-text-muted hover:text-text-primary"
+              }`}>
+              <span className="material-symbols-outlined text-xl">{item.icon}</span>
+              <span className="font-mono text-[8px] uppercase mt-0.5">{item.label}</span>
+            </button>
+          ))}
+        </nav>
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+## STEP 10: Update ResultTable.tsx colors to V2 tokens
+
+In ResultTable.tsx, replace all old color classes:
+- `bg-surface-low` → `bg-bg-card`
+- `bg-surface-container` → `bg-bg-card-inner`
+- `bg-surface-container-high` / `bg-surface-high` → `bg-surface-high`
+- `border-surface-high` → `border-border-default`
+- `bg-surface-dim` → `bg-bg-sidebar`
+- `text-outline` → `text-text-muted`
+- `text-on-surface-variant` → `text-text-secondary`
+- `text-on-surface` → `text-text-primary`
+- `text-primary-fixed` → `text-under-text`
+- `text-secondary` → `text-over-text`
+- UNDER badge: `bg-under-bg text-under-text`
+- OVER badge: `bg-over-bg text-over-text`
+- hover: `hover:bg-surface-high`
+
+---
+
+## STEP 11: Run tests
+```bash
+npm run test
+```
+All 12 must pass. Fix any failures.
+
+---
+
+## STEP 12: Build
+```bash
+npm run build
+```
+Zero TypeScript errors.
+
+---
+
+## STEP 13: Start dev server (tmux window "dev")
+Kill existing if running, then:
+```bash
+tmux send-keys -t polyscan-dev:dev C-c '' C-m
+sleep 2
+tmux send-keys -t polyscan-dev:dev "cd /home/dev/projects/polyscan && npm run dev" C-m
+```
+
+---
+
+## STEP 14: Restart tunnel (tmux window "tunnel")
+```bash
+tmux send-keys -t polyscan-dev:tunnel C-c '' C-m
+sleep 2
+tmux send-keys -t polyscan-dev:tunnel "cloudflared tunnel --protocol http2 --url http://localhost:5173" C-m
+```
+Wait 15s, capture the `https://*.trycloudflare.com` URL.
+
+---
+
+## STEP 15: Verify with web_fetch
+Fetch the tunnel URL. Confirm HTML contains "POLYSCAN".
+If broken → fix and retry.
+
+---
+
+## STEP 16: Report
+- ✅/❌ Tests
+- ✅/❌ Build
+- 🌐 Tunnel URL
+- Visual summary

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,95 +1,160 @@
 import { useState } from "react"
 import { ScannerPage } from "./components/ScannerPage"
+import { StatsBar } from "./components/StatsBar"
+import { FilterBar } from "./components/FilterBar"
 import { useScan } from "./hooks/useScan"
+import type { FilterDirection } from "./types"
 
-type NavItem = "terminal" | "scanners" | "history" | "settings"
+type NavItem = "terminal" | "history" | "settings"
+
 const navItems = [
   { id: "terminal" as NavItem, icon: "terminal", label: "TERMINAL" },
-  { id: "scanners" as NavItem, icon: "troubleshoot", label: "SCANNERS" },
   { id: "history" as NavItem, icon: "history", label: "HISTORY" },
   { id: "settings" as NavItem, icon: "settings", label: "SETTINGS" },
 ]
 
 export default function App() {
   const [active, setActive] = useState<NavItem>("terminal")
-  const { isScanning, scan } = useScan(0.03)
+  const [minGap, setMinGap] = useState(0.03)
+  const [direction, setDirection] = useState<FilterDirection>("ALL")
+  const { results, isScanning, lastScanAt, totalScanned, error, scan } = useScan(minGap)
+  const filtered = results.filter(r => direction === "ALL" ? true : r.direction === direction)
+
   return (
-    <div className="min-h-screen bg-surface text-on-surface flex">
-      {/* Desktop Sidebar */}
-      <aside className="hidden lg:flex flex-col fixed left-0 top-0 h-full w-64 bg-surface-dim border-r border-surface-high z-40">
-        <div className="p-6 border-b border-surface-container">
-          <div className="font-sg text-xl font-black tracking-tighter text-primary-fixed uppercase">POLYSCAN</div>
-          <div className="font-mono text-[9px] text-outline tracking-widest mt-1">v1.0.0-ALPHA</div>
-        </div>
-        <nav className="flex-1 mt-2">
-          {navItems.map(item => (
-            <button key={item.id} onClick={() => setActive(item.id)}
-              className={`w-full flex items-center gap-3 px-4 py-3 font-mono text-sm font-bold uppercase tracking-tight transition-colors ${
-                active===item.id ? "bg-surface-container text-primary-fixed border-r-2 border-primary-fixed" : "text-outline hover:text-on-surface"
-              }`}
-              style={active===item.id ? { boxShadow:"0 0 10px rgba(0,253,135,0.2)" } : {}}>
-              <span className="material-symbols-outlined">{item.icon}</span>
-              {item.label}
-            </button>
-          ))}
-        </nav>
-        <div className="p-4 border-t border-surface-container">
-          <div className="flex items-center justify-between">
+    <div className="min-h-screen bg-bg-base text-text-primary flex flex-col">
+
+      {/* Desktop layout */}
+      <div className="hidden lg:flex flex-1">
+
+        {/* Sidebar 240px */}
+        <aside className="w-60 flex-shrink-0 bg-bg-sidebar border-r border-border-default flex flex-col fixed top-0 left-0 h-full z-40">
+          {/* Brand */}
+          <div className="px-5 py-5 border-b border-border-default">
             <div className="flex items-center gap-2">
-              <div className={`w-2 h-2 rounded-full ${isScanning ? "bg-primary-fixed animate-pulse" : "bg-outline"}`}></div>
-              <span className="text-[10px] font-mono text-on-surface-variant">LIVE FEED</span>
+              <span className="material-symbols-outlined text-primary text-lg">terminal</span>
+              <span className="font-mono font-bold text-primary tracking-widest text-sm uppercase">POLYSCAN</span>
             </div>
-            <span className="text-[10px] font-mono text-primary-fixed">14MS</span>
+            <div className="text-[9px] font-mono text-text-muted mt-1">v1.0.0 &middot; Arbitrage Scanner</div>
           </div>
-        </div>
-      </aside>
 
-      {/* Tablet Sidebar */}
-      <aside className="hidden md:flex lg:hidden flex-col fixed left-0 top-0 h-full w-16 bg-surface-dim border-r border-surface-high z-40">
-        <div className="p-4 border-b border-surface-container flex justify-center">
-          <span className="material-symbols-outlined text-primary-fixed">terminal</span>
-        </div>
-        <nav className="flex-1 mt-2">
-          {navItems.map(item => (
-            <button key={item.id} onClick={() => setActive(item.id)}
-              className={`w-full flex justify-center py-3 transition-colors ${active===item.id?"text-primary-fixed":"text-outline hover:text-on-surface"}`}>
-              <span className="material-symbols-outlined">{item.icon}</span>
-            </button>
-          ))}
-        </nav>
-      </aside>
+          {/* Nav */}
+          <nav className="py-2">
+            {navItems.map(item => (
+              <button key={item.id} onClick={() => setActive(item.id)}
+                className={`w-full flex items-center gap-3 px-5 py-2.5 text-xs font-mono uppercase transition-colors ${
+                  active === item.id
+                    ? "text-primary border-r-2 border-primary bg-bg-card"
+                    : "text-text-muted hover:text-text-primary"
+                }`}>
+                <span className="material-symbols-outlined text-base">{item.icon}</span>
+                {item.label}
+              </button>
+            ))}
+          </nav>
 
-      {/* Main */}
-      <main className="flex-1 lg:ml-64 md:ml-16 flex flex-col min-h-screen pb-16 md:pb-0">
-        <header className="flex items-center justify-between px-4 lg:px-6 h-14 bg-surface-dim border-b border-surface-high sticky top-0 z-30">
-          <div className="flex items-center gap-3">
-            <span className="material-symbols-outlined text-primary-fixed">terminal</span>
-            <h1 className="font-sg font-black tracking-tighter text-primary-fixed uppercase text-lg lg:hidden">POLYSCAN</h1>
-            <span className="hidden lg:block text-[10px] font-mono text-outline uppercase tracking-widest">TERMINAL_CORE</span>
+          <div className="flex-1" />
+
+          {/* Stats + Filter in sidebar */}
+          <div className="px-4 pb-4 space-y-5 border-t border-border-default pt-4">
+            <StatsBar
+              totalScanned={totalScanned}
+              found={filtered.length}
+              lastScanAt={lastScanAt}
+              isScanning={isScanning}
+            />
+            <FilterBar
+              minGap={minGap}
+              direction={direction}
+              onMinGapChange={setMinGap}
+              onDirectionChange={setDirection}
+            />
           </div>
-          <button onClick={scan} disabled={isScanning}
-            className="bg-primary-fixed text-black text-xs font-mono font-bold px-4 py-2 uppercase hover:bg-primary-dim transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-            {isScanning ? "SCANNING\u2026" : "SCAN NOW"}
+        </aside>
+
+        {/* Main content */}
+        <main className="ml-60 flex-1 flex flex-col min-h-screen">
+          {/* Top bar */}
+          <header className="flex items-center justify-between px-6 h-12 bg-bg-sidebar border-b border-border-default sticky top-0 z-30">
+            <div className="flex items-center gap-6">
+              <span className="text-[10px] font-mono text-text-muted uppercase tracking-widest">TERMINAL_CORE</span>
+              <button className="text-[10px] font-mono text-primary border-b border-primary pb-0.5">Live Arbitrage Feed</button>
+            </div>
+            <div className="flex items-center gap-3">
+              {lastScanAt && (
+                <span className="text-[9px] font-mono text-text-muted">
+                  {lastScanAt.toUTCString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, "$1")} UTC
+                </span>
+              )}
+              <button
+                onClick={scan}
+                disabled={isScanning}
+                className="px-4 py-1.5 text-xs font-mono font-bold uppercase rounded-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  background: "#33ff99",
+                  color: "#000",
+                }}
+                onMouseEnter={e => { if (!isScanning) (e.target as HTMLElement).style.background = "#00ccc9" }}
+                onMouseLeave={e => { (e.target as HTMLElement).style.background = "#33ff99" }}
+              >
+                {isScanning ? "SCANNING\u2026" : "SCAN NOW"}
+              </button>
+            </div>
+          </header>
+
+          {/* Page */}
+          {active === "terminal" && <ScannerPage results={filtered} error={error} />}
+          {active !== "terminal" && (
+            <div className="flex-1 flex items-center justify-center">
+              <span className="font-mono text-text-muted text-sm uppercase">Coming Soon \u2014 {active}</span>
+            </div>
+          )}
+        </main>
+      </div>
+
+      {/* Mobile layout */}
+      <div className="lg:hidden flex flex-col flex-1">
+        {/* Mobile header */}
+        <header className="flex items-center justify-between px-4 h-12 bg-bg-sidebar border-b border-border-default sticky top-0 z-30">
+          <div className="flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary">terminal</span>
+            <span className="font-mono font-bold text-primary tracking-widest text-sm uppercase">POLYSCAN</span>
+          </div>
+          <button
+            onClick={scan}
+            disabled={isScanning}
+            className="px-3 py-1.5 text-xs font-mono font-bold uppercase rounded-sm disabled:opacity-50"
+            style={{ background: "#33ff99", color: "#000" }}
+          >
+            {isScanning ? "\u2026" : "SCAN"}
           </button>
         </header>
-        {active==="terminal" && <ScannerPage />}
-        {active!=="terminal" && (
-          <div className="flex-1 flex items-center justify-center">
-            <span className="font-mono text-outline text-sm uppercase">Coming Soon \u2014 {active}</span>
-          </div>
-        )}
-      </main>
 
-      {/* Mobile Bottom Nav */}
-      <nav className="md:hidden fixed bottom-0 left-0 right-0 flex bg-surface-dim border-t border-surface-high z-40">
-        {navItems.map(item => (
-          <button key={item.id} onClick={() => setActive(item.id)}
-            className={`flex-1 flex flex-col items-center justify-center py-3 transition-colors ${active===item.id?"text-primary-fixed bg-surface-low":"text-outline hover:text-on-surface"}`}>
-            <span className="material-symbols-outlined">{item.icon}</span>
-            <span className="font-sg text-[9px] uppercase mt-1">{item.label}</span>
-          </button>
-        ))}
-      </nav>
+        {/* Mobile stats */}
+        <div className="px-4 pt-4 pb-2">
+          <StatsBar totalScanned={totalScanned} found={filtered.length} lastScanAt={lastScanAt} isScanning={isScanning} />
+        </div>
+        <div className="px-4 pb-4">
+          <FilterBar minGap={minGap} direction={direction} onMinGapChange={setMinGap} onDirectionChange={setDirection} />
+        </div>
+
+        {/* Mobile content */}
+        <main className="flex-1 pb-16">
+          {active === "terminal" && <ScannerPage results={filtered} error={error} />}
+        </main>
+
+        {/* Mobile bottom nav */}
+        <nav className="fixed bottom-0 left-0 right-0 flex bg-bg-sidebar border-t border-border-default z-40">
+          {navItems.map(item => (
+            <button key={item.id} onClick={() => setActive(item.id)}
+              className={`flex-1 flex flex-col items-center justify-center py-3 transition-colors ${
+                active === item.id ? "text-primary" : "text-text-muted hover:text-text-primary"
+              }`}>
+              <span className="material-symbols-outlined text-xl">{item.icon}</span>
+              <span className="font-mono text-[8px] uppercase mt-0.5">{item.label}</span>
+            </button>
+          ))}
+        </nav>
+      </div>
     </div>
   )
 }

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,31 +1,42 @@
 import type { FilterDirection } from "../types"
+
 interface Props {
   minGap: number
   direction: FilterDirection
   onMinGapChange: (v: number) => void
   onDirectionChange: (d: FilterDirection) => void
 }
+
 export function FilterBar({ minGap, direction, onMinGapChange, onDirectionChange }: Props) {
   return (
-    <div className="bg-surface-low border border-surface-high p-4 lg:p-6 space-y-4">
-      <h3 className="text-[10px] font-mono text-outline uppercase tracking-widest">Control_Parameters</h3>
+    <div className="space-y-4">
+      <h3 className="text-[9px] font-mono text-text-muted uppercase tracking-widest">Filters</h3>
+
+      {/* Min gap slider */}
       <div className="space-y-2">
-        <div className="flex justify-between text-[10px] font-mono">
-          <span className="text-outline uppercase">Min Gap Threshold</span>
-          <span className="text-primary-fixed">{(minGap * 100).toFixed(0)}\u00a2 minimum</span>
+        <div className="flex justify-between text-[9px] font-mono">
+          <span className="text-text-muted uppercase">Min Gap</span>
+          <span className="text-primary">{(minGap * 100).toFixed(0)}\u00a2</span>
         </div>
         <input
           type="range" min="1" max="20" value={Math.round(minGap * 100)}
           onChange={e => onMinGapChange(Number(e.target.value) / 100)}
-          className="w-full h-1 bg-surface-highest appearance-none cursor-pointer accent-[#00fd87]"
+          className="w-full h-0.5 bg-border-default appearance-none cursor-pointer accent-[#33ff99]"
         />
       </div>
-      <div className="flex bg-surface-lowest border border-surface-high">
+
+      {/* Direction toggle */}
+      <div className="flex gap-1">
         {(["ALL","OVER","UNDER"] as FilterDirection[]).map(d => (
-          <button key={d} onClick={() => onDirectionChange(d)}
-            className={`flex-1 py-2 text-[10px] font-mono font-bold uppercase transition-colors ${
-              direction === d ? "bg-primary-fixed text-black" : "bg-surface-dim text-outline hover:text-on-surface"
-            }`}>{d}</button>
+          <button
+            key={d}
+            onClick={() => onDirectionChange(d)}
+            className={`flex-1 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm transition-colors ${
+              direction === d
+                ? "bg-filter-active text-on-filter"
+                : "bg-bg-card border border-border-default text-text-muted hover:text-[#c0c0c0]"
+            }`}
+          >{d}</button>
         ))}
       </div>
     </div>

--- a/src/components/GapBarChart.tsx
+++ b/src/components/GapBarChart.tsx
@@ -1,37 +1,46 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts"
 import type { GapResult } from "../types"
+
 interface Props { results: GapResult[] }
+
 export function GapBarChart({ results }: Props) {
   const data = results.slice(0, 20).map(r => ({
-    name: r.question.slice(0, 20) + "\u2026",
+    name: r.question.slice(0, 18) + "\u2026",
     gap: parseFloat((r.gap * 100).toFixed(2)),
     direction: r.direction,
   }))
+
   if (data.length === 0) return (
-    <div className="bg-surface-low border border-surface-high p-6 flex items-center justify-center h-40">
-      <span className="text-outline font-mono text-xs">NO DATA \u2014 RUN SCAN</span>
+    <div className="bg-bg-card border border-border-default rounded-sm p-6 flex items-center justify-center h-40">
+      <span className="text-text-muted font-mono text-xs uppercase">No signals \u2014 run scan</span>
     </div>
   )
+
   return (
-    <div className="bg-surface-low border border-surface-high p-4 lg:p-6">
+    <div className="bg-bg-card border border-border-default rounded-sm p-4">
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-[10px] font-mono text-outline uppercase tracking-widest">Real-Time Gap Distribution</h3>
-        <div className="flex gap-4 text-[8px] font-mono">
-          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block bg-primary-fixed"></span>UNDER</span>
-          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block bg-secondary"></span>OVER</span>
+        <h3 className="text-[9px] font-mono text-text-muted uppercase tracking-widest">Gap Distribution</h3>
+        <div className="flex gap-3 text-[8px] font-mono">
+          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none" style={{background:"#33ff99"}}></span>UNDER</span>
+          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none" style={{background:"#ff5f52"}}></span>OVER</span>
         </div>
       </div>
-      <ResponsiveContainer width="100%" height={160}>
-        <BarChart data={data}>
+      <ResponsiveContainer width="100%" height={140}>
+        <BarChart data={data} barCategoryGap="20%">
           <XAxis dataKey="name" tick={false} axisLine={false} tickLine={false} />
-          <YAxis tick={{ fill:"#849585", fontSize:9, fontFamily:"JetBrains Mono" }} axisLine={false} tickLine={false} unit="\u00a2" />
-          <Tooltip
-            contentStyle={{ background:"#201f1f", border:"1px solid #353534", borderRadius:0, fontSize:10, fontFamily:"JetBrains Mono" }}
-            labelStyle={{ color:"#b9cbb9" }}
-            formatter={(v) => [`${v}¢`, "Gap"]}
+          <YAxis
+            tick={{ fill:"#6b6882", fontSize:9, fontFamily:"JetBrains Mono" }}
+            axisLine={false} tickLine={false} unit="\u00a2"
           />
-          <Bar dataKey="gap">
-            {data.map((entry, i) => <Cell key={i} fill={entry.direction === "UNDER" ? "#00fd87" : "#ffb4ab"} />)}
+          <Tooltip
+            contentStyle={{ background:"#22202e", border:"1px solid #2e2c3e", borderRadius:"6px", fontSize:10, fontFamily:"JetBrains Mono" }}
+            labelStyle={{ color:"#c0c0c0" }}
+            formatter={(v) => [`${v}\u00a2`, "Gap"]}
+          />
+          <Bar dataKey="gap" radius={[2,2,0,0]}>
+            {data.map((entry, i) => (
+              <Cell key={i} fill={entry.direction === "UNDER" ? "#33ff99" : "#ff5f52"} opacity={0.85} />
+            ))}
           </Bar>
         </BarChart>
       </ResponsiveContainer>

--- a/src/components/ResultTable.tsx
+++ b/src/components/ResultTable.tsx
@@ -6,17 +6,17 @@ export function ResultTable({ results }: { results: GapResult[] }) {
   const [sortAsc, setSortAsc] = useState(false)
   const sorted = [...results].sort((a, b) => sortAsc ? a[sortKey]-b[sortKey] : b[sortKey]-a[sortKey])
   const toggle = (k: SortKey) => { if (k===sortKey) setSortAsc(!sortAsc); else { setSortKey(k); setSortAsc(false) } }
-  const th = "px-4 py-3 font-normal text-[10px] font-mono text-outline uppercase tracking-widest cursor-pointer hover:text-on-surface select-none"
+  const th = "px-4 py-3 font-normal text-[10px] font-mono text-text-muted uppercase tracking-widest cursor-pointer hover:text-text-primary select-none"
   return (
-    <div className="border border-surface-high overflow-hidden">
-      <div className="px-5 py-3 border-b border-surface-high flex justify-between items-center bg-surface-dim">
-        <span className="text-[10px] font-mono text-outline uppercase tracking-widest">ACTIVE_ARBITRAGE_SIGNALS</span>
-        <span className="text-[10px] font-mono text-outline">{results.length} signals</span>
+    <div className="border border-border-default rounded-sm overflow-hidden">
+      <div className="px-5 py-3 border-b border-border-default flex justify-between items-center bg-bg-sidebar">
+        <span className="text-[10px] font-mono text-text-muted uppercase tracking-widest">ACTIVE_ARBITRAGE_SIGNALS</span>
+        <span className="text-[10px] font-mono text-text-muted">{results.length} signals</span>
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-left font-mono text-[11px]">
           <thead>
-            <tr className="bg-surface-container border-b border-surface-highest">
+            <tr className="bg-bg-card-inner border-b border-border-default">
               <th className={th + " text-left"}>Market / Question</th>
               {(["yes","no","sum","gap"] as SortKey[]).map(k => (
                 <th key={k} className={th + " text-right"} onClick={() => toggle(k)}>
@@ -28,21 +28,21 @@ export function ResultTable({ results }: { results: GapResult[] }) {
           </thead>
           <tbody>
             {sorted.length === 0 ? (
-              <tr><td colSpan={6} className="px-5 py-8 text-center text-outline text-xs">No gaps found \u2014 try lowering the threshold or run a scan</td></tr>
+              <tr><td colSpan={6} className="px-5 py-8 text-center text-text-muted text-xs">No gaps found \u2014 try lowering the threshold or run a scan</td></tr>
             ) : sorted.map((r, i) => (
               <tr key={i}
-                className={`border-b border-surface-dim hover:bg-surface-high transition-colors cursor-pointer ${i%2===0?"bg-surface-low":"bg-surface-container"}`}
+                className={`border-b border-border-subtle hover:bg-surface-high transition-colors cursor-pointer ${i%2===0?"bg-bg-card":"bg-bg-card-inner"}`}
                 onClick={() => window.open(`https://polymarket.com/event/${r.slug}`,"_blank")}
               >
-                <td className="px-4 py-3 text-on-surface max-w-[200px] lg:max-w-xs truncate">{r.question}</td>
-                <td className="px-4 py-3 text-right text-on-surface-variant">{r.yes.toFixed(3)}</td>
-                <td className="px-4 py-3 text-right text-on-surface-variant">{r.no.toFixed(3)}</td>
-                <td className="px-4 py-3 text-right text-on-surface-variant">{r.sum.toFixed(3)}</td>
-                <td className={`px-4 py-3 text-right font-bold ${r.direction==="UNDER"?"text-primary-fixed":"text-secondary"}`}>
+                <td className="px-4 py-3 text-text-primary max-w-[200px] lg:max-w-xs truncate">{r.question}</td>
+                <td className="px-4 py-3 text-right text-text-secondary">{r.yes.toFixed(3)}</td>
+                <td className="px-4 py-3 text-right text-text-secondary">{r.no.toFixed(3)}</td>
+                <td className="px-4 py-3 text-right text-text-secondary">{r.sum.toFixed(3)}</td>
+                <td className={`px-4 py-3 text-right font-bold ${r.direction==="UNDER"?"text-under-text":"text-over-text"}`}>
                   {r.direction==="UNDER"?"-":"+"}{(r.gap*100).toFixed(2)}%
                 </td>
                 <td className="px-4 py-3 text-center">
-                  <span className={`inline-block px-2 py-0.5 text-[9px] font-bold uppercase ${r.direction==="UNDER"?"bg-primary-fixed text-black":"bg-secondary text-black"}`}>
+                  <span className={`inline-block px-2 py-0.5 text-[9px] font-bold uppercase rounded-sm ${r.direction==="UNDER"?"bg-under-bg text-under-text":"bg-over-bg text-over-text"}`}>
                     {r.direction}
                   </span>
                 </td>

--- a/src/components/ScannerPage.tsx
+++ b/src/components/ScannerPage.tsx
@@ -1,27 +1,63 @@
 import { useState } from "react"
-import { useScan } from "../hooks/useScan"
-import { StatsBar } from "./StatsBar"
-import { FilterBar } from "./FilterBar"
 import { GapBarChart } from "./GapBarChart"
 import { ResultTable } from "./ResultTable"
-import type { FilterDirection } from "../types"
+import { SignalCard } from "./SignalCard"
+import type { GapResult } from "../types"
 
-export function ScannerPage() {
-  const [minGap, setMinGap] = useState(0.03)
-  const [direction, setDirection] = useState<FilterDirection>("ALL")
-  const { results, isScanning, lastScanAt, totalScanned, error } = useScan(minGap)
-  const filtered = results.filter(r => direction === "ALL" ? true : r.direction === direction)
+interface Props {
+  results: GapResult[]
+  error: string | null
+}
+
+export function ScannerPage({ results, error }: Props) {
+  const [view, setView] = useState<"cards" | "table">("cards")
+
   return (
-    <div className="p-4 lg:p-6 space-y-4 lg:space-y-6">
+    <div className="p-4 lg:p-6 space-y-4">
       {error && (
-        <div className="bg-secondary-container border border-secondary p-3 text-secondary font-mono text-xs">{"\u26A0"} {error}</div>
+        <div className="bg-over-bg border border-over-text/30 p-3 text-over-text font-mono text-xs rounded-sm">
+          {"\u26A0"} {error}
+        </div>
       )}
-      <StatsBar totalScanned={totalScanned} found={filtered.length} lastScanAt={lastScanAt} isScanning={isScanning} />
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 lg:gap-6">
-        <div className="lg:col-span-4"><FilterBar minGap={minGap} direction={direction} onMinGapChange={setMinGap} onDirectionChange={setDirection} /></div>
-        <div className="lg:col-span-8"><GapBarChart results={filtered} /></div>
+
+      {/* Chart */}
+      <GapBarChart results={results} />
+
+      {/* View toggle + count */}
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] font-mono text-text-muted uppercase">
+          {results.length} signals
+        </span>
+        <div className="flex gap-1">
+          <button
+            onClick={() => setView("cards")}
+            className={`px-3 py-1 text-[9px] font-mono uppercase rounded-sm transition-colors ${
+              view === "cards" ? "bg-primary text-on-primary" : "bg-bg-card border border-border-default text-text-muted hover:text-text-primary"
+            }`}
+          >Cards</button>
+          <button
+            onClick={() => setView("table")}
+            className={`px-3 py-1 text-[9px] font-mono uppercase rounded-sm transition-colors ${
+              view === "table" ? "bg-primary text-on-primary" : "bg-bg-card border border-border-default text-text-muted hover:text-text-primary"
+            }`}
+          >Table</button>
+        </div>
       </div>
-      <ResultTable results={filtered} />
+
+      {/* Content */}
+      {view === "cards" ? (
+        results.length === 0 ? (
+          <div className="bg-bg-card border border-border-default rounded-sm p-8 text-center">
+            <p className="text-text-muted font-mono text-xs uppercase">No signals found {"\u2014"} try lowering threshold or run a scan</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+            {results.map((r, i) => <SignalCard key={i} result={r} />)}
+          </div>
+        )
+      ) : (
+        <ResultTable results={results} />
+      )}
     </div>
   )
 }

--- a/src/components/SignalCard.tsx
+++ b/src/components/SignalCard.tsx
@@ -1,0 +1,99 @@
+import type { GapResult } from "../types"
+
+interface Props {
+  result: GapResult
+}
+
+export function SignalCard({ result }: Props) {
+  const isUnder = result.direction === "UNDER"
+  const gapPct = (result.gap * 100).toFixed(2)
+  const netProfit = (result.gap - 0.04).toFixed(3) // after ~2% fee each side
+
+  // Sparkline bars — 6 bars with varying heights
+  const sparkBars = [0.3, 0.6, 0.45, 0.8, 0.55, 1.0]
+
+  return (
+    <div
+      className="bg-bg-card border border-border-default rounded-sm p-4 cursor-pointer hover:border-border-subtle transition-colors space-y-3"
+      onClick={() => window.open(`https://polymarket.com/event/${result.slug}`, "_blank")}
+    >
+      {/* Header: question + direction badge */}
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-text-primary text-xs font-body leading-snug line-clamp-2 flex-1">
+          {result.question}
+        </p>
+        <span className={`shrink-0 inline-block px-2 py-0.5 text-[9px] font-mono font-bold uppercase rounded-sm ${
+          isUnder
+            ? "bg-under-bg text-under-text"
+            : result.direction === "OVER"
+            ? "bg-over-bg text-over-text"
+            : "bg-surface-high text-text-muted"
+        }`}>
+          {result.direction}
+        </span>
+      </div>
+
+      {/* Sparkline */}
+      <div className="flex items-end gap-0.5 h-6">
+        {sparkBars.map((h, i) => (
+          <div
+            key={i}
+            className="flex-1 rounded-none"
+            style={{
+              height: `${h * 100}%`,
+              background: isUnder
+                ? `rgba(0,253,135,${0.3 + h * 0.6})`
+                : `rgba(255,95,82,${0.3 + h * 0.6})`,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* YES / NO / SUM boxes */}
+      <div className="grid grid-cols-3 gap-1">
+        {[
+          { label: "YES", value: result.yes.toFixed(3) },
+          { label: "NO",  value: result.no.toFixed(3) },
+          { label: "SUM", value: result.sum.toFixed(3) },
+        ].map(({ label, value }) => (
+          <div key={label} className="bg-bg-card-inner border border-border-subtle rounded-sm p-2 text-center">
+            <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">{label}</div>
+            <div className="text-xs font-mono text-text-primary">{value}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Gap % large */}
+      <div className="flex items-end justify-between">
+        <div>
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">GAP</div>
+          <div
+            className="font-mono font-bold leading-none"
+            style={{ fontSize: "44px", color: isUnder ? "#00fd87" : "#ff5f52" }}
+          >
+            {isUnder ? "-" : "+"}{gapPct}%
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">NET PROFIT</div>
+          <div className={`text-sm font-mono font-bold ${Number(netProfit) > 0 ? "text-under-text" : "text-over-text"}`}>
+            {Number(netProfit) > 0 ? "+" : ""}{netProfit}
+          </div>
+        </div>
+      </div>
+
+      {/* Gap bar gradient */}
+      <div className="h-1 w-full bg-border-default rounded-full overflow-hidden">
+        <div
+          className="h-full rounded-full"
+          style={{
+            width: `${Math.min(result.gap * 1000, 100)}%`,
+            background: isUnder
+              ? "linear-gradient(90deg, #00fd87, #00ccc9)"
+              : "linear-gradient(90deg, #ff5f52, #e566ff)",
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -4,25 +4,35 @@ interface Props {
   lastScanAt: Date | null
   isScanning: boolean
 }
+
 export function StatsBar({ totalScanned, found, lastScanAt, isScanning }: Props) {
   const timeStr = lastScanAt
     ? lastScanAt.toUTCString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, "$1") + " UTC"
     : "\u2014"
+
   return (
-    <div className="grid grid-cols-3 gap-1">
-      <div className="bg-surface-low border border-surface-high p-3 lg:p-5 flex flex-col justify-between">
-        <div className="text-[10px] font-mono text-outline uppercase">Markets Scanned</div>
-        <div className="text-2xl lg:text-4xl font-mono font-bold text-on-surface mt-2">{totalScanned.toLocaleString()}</div>
-      </div>
-      <div className="bg-surface-low border border-surface-high p-3 lg:p-5 flex flex-col justify-between">
-        <div className="text-[10px] font-mono text-outline uppercase">Gaps Found</div>
-        <div className="text-2xl lg:text-4xl font-mono font-bold text-primary-fixed mt-2">{String(found).padStart(2, "0")}</div>
-      </div>
-      <div className="bg-surface-low border border-surface-high p-3 lg:p-5 flex flex-col justify-between">
-        <div className="text-[10px] font-mono text-outline uppercase">Last Scan</div>
-        <div className="text-lg lg:text-2xl font-mono font-bold text-on-surface mt-2">
-          {isScanning ? <span className="text-primary-fixed animate-pulse">SCANNING\u2026</span> : timeStr}
+    <div className="space-y-2">
+      {/* Session stats */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="bg-bg-card border border-border-default rounded-sm p-3">
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-1">Scanned</div>
+          <div className="text-xl font-mono font-bold text-text-primary">{totalScanned.toLocaleString()}</div>
         </div>
+        <div className="bg-bg-card border border-border-default rounded-sm p-3">
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-1">Signals</div>
+          <div className="text-xl font-mono font-bold text-primary">{String(found).padStart(2, "0")}</div>
+        </div>
+      </div>
+
+      {/* Live indicator */}
+      <div className="flex items-center justify-between px-1">
+        <div className="flex items-center gap-1.5">
+          <div className={`w-1.5 h-1.5 rounded-full ${isScanning ? "bg-primary animate-pulse" : "bg-text-muted"}`} />
+          <span className="text-[9px] font-mono text-text-muted uppercase">
+            {isScanning ? "SCANNING" : lastScanAt ? "LAST: " + timeStr : "IDLE"}
+          </span>
+        </div>
+        <span className="text-[9px] font-mono text-primary">14MS</span>
       </div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,8 @@
 
 * { box-sizing: border-box; }
 body {
-  background-color: #131313;
-  color: #e5e2e1;
+  background-color: #0e0d14;
+  color: #ffffff;
   font-family: "Inter", sans-serif;
   -webkit-font-smoothing: antialiased;
   margin: 0;
@@ -16,5 +16,5 @@ body {
   line-height: 1;
 }
 ::-webkit-scrollbar { width: 4px; height: 4px; }
-::-webkit-scrollbar-track { background: #131313; }
-::-webkit-scrollbar-thumb { background: #353534; }
+::-webkit-scrollbar-track { background: #0e0d14; }
+::-webkit-scrollbar-thumb { background: #2e2c3e; }

--- a/stitch/layout-1-signal-first.html
+++ b/stitch/layout-1-signal-first.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html class="dark" lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>POLYSCAN — Layout 1: Signal-First</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<script>
+tailwind.config = {
+  darkMode:"class",
+  theme:{ extend:{ colors:{
+    "primary-fixed":"#00fd87","primary-dim":"#00ed7e",
+    "surface":"#131313","surface-low":"#1c1b1b","surface-container":"#201f1f",
+    "surface-high":"#2a2a2a","surface-highest":"#353534","surface-dim":"#0e0e0e",
+    "on-surface":"#e5e2e1","on-surface-variant":"#b9cbb9",
+    "outline":"#849585","outline-variant":"#3b4b3d",
+    "secondary":"#ffb4ab","secondary-container":"#8d1d1e",
+  }, fontFamily:{ mono:['"JetBrains Mono"','monospace'], sg:['"Space Grotesk"','sans-serif'] },
+  borderRadius:{ DEFAULT:"0px", lg:"0px", xl:"0px", full:"9999px" } } }
+}
+</script>
+<style>
+* { box-sizing:border-box; }
+body { background:#131313; color:#e5e2e1; font-family:'Space Grotesk',sans-serif; -webkit-font-smoothing:antialiased; margin:0; }
+.material-symbols-outlined { font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24; display:inline-block; line-height:1; }
+::-webkit-scrollbar { width:4px; height:4px; }
+::-webkit-scrollbar-track { background:#131313; }
+::-webkit-scrollbar-thumb { background:#353534; }
+</style>
+</head>
+<body class="min-h-screen">
+
+<!-- STICKY STATS HEADER — สิ่งสำคัญอยู่บนสุดตลอดเวลา -->
+<header class="sticky top-0 z-50 bg-surface-dim border-b border-surface-high">
+  <!-- Brand + Scan button -->
+  <div class="flex items-center justify-between px-4 py-2 border-b border-surface-container">
+    <div class="flex items-center gap-2">
+      <span class="material-symbols-outlined text-primary-fixed text-sm">terminal</span>
+      <span class="font-sg font-black text-primary-fixed uppercase tracking-tighter text-base">POLYSCAN</span>
+      <span class="font-mono text-[9px] text-outline ml-1">v1.0-ALPHA</span>
+    </div>
+    <button id="scan-btn" onclick="startScan()" class="bg-primary-fixed text-black text-[10px] font-mono font-bold px-4 py-2 uppercase hover:bg-primary-dim transition-colors flex items-center gap-1">
+      <span class="material-symbols-outlined text-sm">radar</span>
+      SCAN NOW
+    </button>
+  </div>
+  <!-- Inline stats — always visible -->
+  <div class="grid grid-cols-3 divide-x divide-surface-container">
+    <div class="px-4 py-2 flex items-center gap-3">
+      <span class="material-symbols-outlined text-outline text-sm">storage</span>
+      <div>
+        <div class="text-[9px] font-mono text-outline uppercase">Scanned</div>
+        <div class="text-lg font-mono font-bold text-on-surface leading-none">1,243</div>
+      </div>
+    </div>
+    <div class="px-4 py-2 flex items-center gap-3">
+      <span class="material-symbols-outlined text-primary-fixed text-sm">crisis_alert</span>
+      <div>
+        <div class="text-[9px] font-mono text-outline uppercase">Signals</div>
+        <div class="text-lg font-mono font-bold text-primary-fixed leading-none">07</div>
+      </div>
+    </div>
+    <div class="px-4 py-2 flex items-center gap-3">
+      <div class="w-2 h-2 rounded-full bg-primary-fixed animate-pulse"></div>
+      <div>
+        <div class="text-[9px] font-mono text-outline uppercase">Last Scan</div>
+        <div class="text-lg font-mono font-bold text-on-surface leading-none">06:45<span class="text-xs font-normal text-outline ml-1">UTC</span></div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<main class="max-w-4xl mx-auto px-4 py-4 space-y-4 pb-20">
+
+  <!-- FILTER BAR — compact, inline -->
+  <div class="flex flex-col sm:flex-row gap-3 items-start sm:items-center bg-surface-container border border-surface-high px-4 py-3">
+    <span class="font-mono text-[9px] text-outline uppercase whitespace-nowrap">Filter:</span>
+    <div class="flex items-center gap-3 flex-1 min-w-0">
+      <span class="font-mono text-[9px] text-outline uppercase whitespace-nowrap">Min Gap</span>
+      <input id="gap-slider" type="range" min="1" max="20" value="3"
+        class="flex-1 h-0.5 bg-surface-highest appearance-none cursor-pointer accent-[#00fd87]"
+        oninput="updateFilter()"/>
+      <span id="gap-val" class="font-mono text-[10px] text-primary-fixed whitespace-nowrap w-12">3¢</span>
+    </div>
+    <div class="flex bg-surface-highest" id="dir-btns">
+      <button onclick="setDir('ALL',this)" class="dir active px-3 py-1 text-[9px] font-mono font-bold uppercase bg-primary-fixed text-black transition-colors" data-dir="ALL">ALL</button>
+      <button onclick="setDir('OVER',this)" class="dir px-3 py-1 text-[9px] font-mono font-bold uppercase text-outline hover:text-on-surface transition-colors" data-dir="OVER">OVER</button>
+      <button onclick="setDir('UNDER',this)" class="dir px-3 py-1 text-[9px] font-mono font-bold uppercase text-outline hover:text-on-surface transition-colors" data-dir="UNDER">UNDER</button>
+    </div>
+    <span id="count-label" class="font-mono text-[9px] text-outline whitespace-nowrap">5 signals</span>
+  </div>
+
+  <!-- SIGNAL TABLE — primary content, front and center -->
+  <div class="border border-surface-high overflow-hidden">
+    <div class="bg-surface-container px-4 py-2 flex justify-between items-center border-b border-surface-high">
+      <span class="font-mono text-[9px] text-outline uppercase tracking-widest">⚡ ACTIVE ARBITRAGE SIGNALS</span>
+      <span class="font-mono text-[9px] text-primary-fixed">LIVE</span>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="w-full font-mono text-xs" id="signal-table">
+        <thead>
+          <tr class="bg-surface-container border-b border-surface-highest text-[9px] uppercase text-outline">
+            <th class="px-4 py-3 text-left font-normal">Market</th>
+            <th class="px-4 py-3 text-right font-normal cursor-pointer hover:text-on-surface" onclick="sortBy('gap')">GAP ↕</th>
+            <th class="px-4 py-3 text-center font-normal">DIR</th>
+            <th class="px-4 py-3 text-right font-normal hidden sm:table-cell">YES</th>
+            <th class="px-4 py-3 text-right font-normal hidden sm:table-cell">NO</th>
+            <th class="px-4 py-3 text-right font-normal hidden sm:table-cell">NET</th>
+          </tr>
+        </thead>
+        <tbody id="table-body">
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" data-dir="UNDER" data-gap="7" onclick="window.open('#','_blank')">
+            <td class="px-4 py-3 text-on-surface max-w-[180px] truncate">Fed Rate Hike Sept 2024</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-7.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black uppercase">UNDER</span></td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.89</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.04</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+5.0%</td>
+          </tr>
+          <tr class="border-b border-surface-container bg-surface-low hover:bg-surface-high transition-colors cursor-pointer" data-dir="OVER" data-gap="5" onclick="window.open('#','_blank')">
+            <td class="px-4 py-3 text-on-surface max-w-[180px] truncate">ETH ETF Approved by August?</td>
+            <td class="px-4 py-3 text-right font-bold text-secondary">+5.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-secondary text-black text-[8px] font-black uppercase">OVER</span></td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.681</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.344</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+3.0%</td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" data-dir="UNDER" data-gap="4" onclick="window.open('#','_blank')">
+            <td class="px-4 py-3 text-on-surface max-w-[180px] truncate">Solana Breakpoint Announcement?</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-4.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black uppercase">UNDER</span></td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.22</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.74</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+2.0%</td>
+          </tr>
+          <tr class="border-b border-surface-container bg-surface-low hover:bg-surface-high transition-colors cursor-pointer" data-dir="UNDER" data-gap="3" onclick="window.open('#','_blank')">
+            <td class="px-4 py-3 text-on-surface max-w-[180px] truncate">Will BTC hit 100k by EOY?</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-3.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black uppercase">UNDER</span></td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.45</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.52</td>
+            <td class="px-4 py-3 text-right font-bold text-outline hidden sm:table-cell">+1.0%</td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" data-dir="OVER" data-gap="8" onclick="window.open('#','_blank')">
+            <td class="px-4 py-3 text-on-surface max-w-[180px] truncate">DOGE hits $1 before halving?</td>
+            <td class="px-4 py-3 text-right font-bold text-secondary">+8.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-secondary text-black text-[8px] font-black uppercase">OVER</span></td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.55</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden sm:table-cell">0.53</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+6.0%</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div id="no-results" class="hidden px-4 py-8 text-center font-mono text-outline text-xs">No signals match current filter — lower threshold or change direction</div>
+  </div>
+
+  <!-- MINI CHART — secondary, below the signals -->
+  <details class="group border border-surface-high">
+    <summary class="flex justify-between items-center px-4 py-3 cursor-pointer bg-surface-container font-mono text-[9px] text-outline uppercase tracking-widest hover:text-on-surface transition-colors">
+      <span>Gap Distribution Chart</span>
+      <span class="group-open:rotate-180 transition-transform material-symbols-outlined text-sm">expand_more</span>
+    </summary>
+    <div class="p-4 bg-surface-low">
+      <div class="flex items-end justify-between gap-1 h-20">
+        <div class="w-full bg-secondary rounded-t-none" style="height:40%" title="OVER +4%"></div>
+        <div class="w-full bg-primary-fixed" style="height:70%" title="UNDER -7%"></div>
+        <div class="w-full bg-primary-fixed" style="height:40%" title="UNDER -4%"></div>
+        <div class="w-full bg-secondary" style="height:50%" title="OVER +5%"></div>
+        <div class="w-full bg-primary-fixed" style="height:30%" title="UNDER -3%"></div>
+        <div class="w-full bg-secondary" style="height:80%" title="OVER +8%"></div>
+        <div class="w-full bg-primary-fixed" style="height:20%" title="UNDER -2%"></div>
+        <div class="w-full bg-secondary" style="height:35%" title="OVER +3.5%"></div>
+      </div>
+      <div class="flex justify-between mt-2 font-mono text-[8px] text-outline">
+        <span class="flex items-center gap-1"><span class="w-2 h-2 inline-block bg-primary-fixed"></span>UNDER</span>
+        <span class="flex items-center gap-1"><span class="w-2 h-2 inline-block bg-secondary"></span>OVER</span>
+      </div>
+    </div>
+  </details>
+</main>
+
+<!-- Mobile bottom nav -->
+<nav class="fixed bottom-0 left-0 right-0 flex bg-surface-dim border-t border-surface-high z-40">
+  <a href="#" class="flex-1 flex flex-col items-center py-3 text-primary-fixed bg-surface-container">
+    <span class="material-symbols-outlined text-sm">terminal</span>
+    <span class="font-sg text-[8px] uppercase mt-0.5">Terminal</span>
+  </a>
+  <a href="#" class="flex-1 flex flex-col items-center py-3 text-outline hover:text-on-surface">
+    <span class="material-symbols-outlined text-sm">history</span>
+    <span class="font-sg text-[8px] uppercase mt-0.5">History</span>
+  </a>
+  <a href="#" class="flex-1 flex flex-col items-center py-3 text-outline hover:text-on-surface">
+    <span class="material-symbols-outlined text-sm">settings</span>
+    <span class="font-sg text-[8px] uppercase mt-0.5">Settings</span>
+  </a>
+</nav>
+
+<script>
+var activeDir = 'ALL';
+function updateFilter(){
+  var v = document.getElementById('gap-slider').value;
+  document.getElementById('gap-val').textContent = v + '¢';
+  applyFilter();
+}
+function setDir(dir, btn){
+  activeDir = dir;
+  document.querySelectorAll('.dir').forEach(function(b){
+    b.classList.remove('bg-primary-fixed','text-black');
+    b.classList.add('text-outline');
+  });
+  btn.classList.add('bg-primary-fixed','text-black');
+  btn.classList.remove('text-outline');
+  applyFilter();
+}
+function applyFilter(){
+  var minGap = parseInt(document.getElementById('gap-slider').value);
+  var rows = document.querySelectorAll('#table-body tr');
+  var shown = 0;
+  rows.forEach(function(row){
+    var dir = row.dataset.dir;
+    var gap = parseInt(row.dataset.gap);
+    var ok = (activeDir==='ALL'||dir===activeDir) && gap>=minGap;
+    row.style.display = ok ? '' : 'none';
+    if(ok) shown++;
+  });
+  document.getElementById('count-label').textContent = shown + ' signals';
+  document.getElementById('no-results').classList.toggle('hidden', shown > 0);
+}
+function startScan(){
+  var btn = document.getElementById('scan-btn');
+  btn.textContent = 'SCANNING…';
+  btn.disabled = true;
+  setTimeout(function(){ btn.innerHTML = '<span class="material-symbols-outlined text-sm">radar</span> SCAN NOW'; btn.disabled=false; }, 2000);
+}
+</script>
+</body>
+</html>

--- a/stitch/layout-2-dashboard-grid.html
+++ b/stitch/layout-2-dashboard-grid.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html class="dark" lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>POLYSCAN — Layout 2: Dashboard Grid</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<script>
+tailwind.config = {
+  darkMode:"class",
+  theme:{ extend:{ colors:{
+    "primary-fixed":"#00fd87","primary-dim":"#00ed7e",
+    "surface":"#131313","surface-low":"#1c1b1b","surface-container":"#201f1f",
+    "surface-high":"#2a2a2a","surface-highest":"#353534","surface-dim":"#0e0e0e",
+    "on-surface":"#e5e2e1","on-surface-variant":"#b9cbb9",
+    "outline":"#849585","outline-variant":"#3b4b3d",
+    "secondary":"#ffb4ab","secondary-container":"#8d1d1e",
+  }, fontFamily:{ mono:['"JetBrains Mono"','monospace'], sg:['"Space Grotesk"','sans-serif'] },
+  borderRadius:{ DEFAULT:"0px", lg:"0px", xl:"0px", full:"9999px" } } }
+}
+</script>
+<style>
+* { box-sizing:border-box; }
+body { background:#131313; color:#e5e2e1; font-family:'Space Grotesk',sans-serif; -webkit-font-smoothing:antialiased; margin:0; }
+.material-symbols-outlined { font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24; display:inline-block; line-height:1; }
+::-webkit-scrollbar { width:4px; height:4px; }
+::-webkit-scrollbar-track { background:#131313; }
+::-webkit-scrollbar-thumb { background:#353534; }
+.spark { background: linear-gradient(to top, #00fd87 0%, #00fd8744 100%); }
+.spark-red { background: linear-gradient(to top, #ffb4ab 0%, #ffb4ab44 100%); }
+</style>
+</head>
+<body class="min-h-screen">
+
+<!-- HEADER -->
+<header class="flex items-center justify-between px-6 h-14 bg-surface-dim border-b border-surface-high sticky top-0 z-50">
+  <div class="flex items-center gap-3">
+    <span class="material-symbols-outlined text-primary-fixed">terminal</span>
+    <span class="font-sg font-black text-primary-fixed uppercase tracking-tighter text-xl">POLYSCAN</span>
+    <span class="font-mono text-[9px] text-outline hidden sm:block">ARBITRAGE SCANNER v1.0</span>
+  </div>
+  <div class="flex items-center gap-3">
+    <div class="flex items-center gap-1.5 font-mono text-[9px] text-outline">
+      <div class="w-1.5 h-1.5 rounded-full bg-primary-fixed animate-pulse"></div>
+      LIVE
+    </div>
+    <button class="bg-primary-fixed text-black text-[10px] font-mono font-bold px-4 py-2 uppercase hover:bg-primary-dim transition-colors">
+      SCAN NOW
+    </button>
+  </div>
+</header>
+
+<div class="p-4 lg:p-6 space-y-4 lg:space-y-6 pb-20">
+
+  <!-- ROW 1: STAT CARDS — 4 column on desktop -->
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+    <div class="bg-surface-container border border-surface-high p-4 flex flex-col justify-between">
+      <div class="font-mono text-[9px] text-outline uppercase">Markets Scanned</div>
+      <div class="text-3xl font-mono font-bold text-on-surface mt-2">1,243</div>
+      <div class="mt-2 font-mono text-[9px] text-outline">↑ 14% vs last scan</div>
+    </div>
+    <div class="bg-surface-container border border-surface-high p-4 flex flex-col justify-between">
+      <div class="font-mono text-[9px] text-outline uppercase">Gaps Found</div>
+      <div class="text-3xl font-mono font-bold text-primary-fixed mt-2">07</div>
+      <div class="mt-2 font-mono text-[9px] text-primary-fixed">⚡ 2 actionable</div>
+    </div>
+    <div class="bg-surface-container border border-surface-high p-4 flex flex-col justify-between">
+      <div class="font-mono text-[9px] text-outline uppercase">Avg Gap Size</div>
+      <div class="text-3xl font-mono font-bold text-on-surface mt-2">4.6<span class="text-sm font-normal text-outline">%</span></div>
+      <div class="mt-2 font-mono text-[9px] text-outline">after 2% fee</div>
+    </div>
+    <div class="bg-surface-container border border-surface-high p-4 flex flex-col justify-between">
+      <div class="font-mono text-[9px] text-outline uppercase">Last Scan</div>
+      <div class="text-3xl font-mono font-bold text-on-surface mt-2">06:45</div>
+      <div class="mt-2 font-mono text-[9px] text-outline">UTC — 3min ago</div>
+    </div>
+  </div>
+
+  <!-- ROW 2: CHART LEFT + FILTER RIGHT -->
+  <div class="grid grid-cols-1 lg:grid-cols-12 gap-4">
+
+    <!-- Bar Chart - wider -->
+    <div class="lg:col-span-8 bg-surface-container border border-surface-high p-4 lg:p-5">
+      <div class="flex justify-between items-center mb-4">
+        <div>
+          <div class="font-mono text-[9px] text-outline uppercase tracking-widest">Gap Distribution</div>
+          <div class="font-mono text-[10px] text-on-surface-variant mt-0.5">Top 20 markets by gap size</div>
+        </div>
+        <div class="flex gap-4 font-mono text-[9px]">
+          <span class="flex items-center gap-1 text-primary-fixed"><span class="w-2 h-2 bg-primary-fixed inline-block"></span>UNDER</span>
+          <span class="flex items-center gap-1 text-secondary"><span class="w-2 h-2 bg-secondary inline-block"></span>OVER</span>
+        </div>
+      </div>
+      <!-- Chart with Y axis labels -->
+      <div class="flex gap-2">
+        <div class="flex flex-col justify-between font-mono text-[8px] text-outline py-1">
+          <span>10%</span><span>7%</span><span>5%</span><span>3%</span><span>0%</span>
+        </div>
+        <div class="flex-1 relative">
+          <!-- Grid lines -->
+          <div class="absolute inset-0 flex flex-col justify-between pointer-events-none">
+            <div class="border-t border-surface-highest w-full"></div>
+            <div class="border-t border-surface-highest w-full"></div>
+            <div class="border-t border-surface-highest w-full"></div>
+            <div class="border-t border-surface-highest w-full"></div>
+            <div class="border-t border-surface-highest w-full"></div>
+          </div>
+          <!-- Bars with tooltips -->
+          <div class="flex items-end gap-0.5 h-32 relative" id="chart">
+            <div class="group relative flex-1 bg-secondary hover:opacity-80 cursor-pointer transition-opacity" style="height:40%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">L2 TVL 45B? · OVER +4.0%</div>
+            </div>
+            <div class="group relative flex-1 bg-primary-fixed hover:opacity-80 cursor-pointer transition-opacity" style="height:70%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">Fed Rate Hike? · UNDER -7.0%</div>
+            </div>
+            <div class="group relative flex-1 bg-secondary hover:opacity-80 cursor-pointer transition-opacity" style="height:50%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">ETH ETF? · OVER +5.0%</div>
+            </div>
+            <div class="group relative flex-1 bg-primary-fixed hover:opacity-80 cursor-pointer transition-opacity" style="height:80%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">DOGE $1? · UNDER -8.0%</div>
+            </div>
+            <div class="group relative flex-1 bg-primary-fixed hover:opacity-80 cursor-pointer transition-opacity" style="height:40%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">BTC 100k? · UNDER -4.0%</div>
+            </div>
+            <div class="group relative flex-1 bg-secondary hover:opacity-80 cursor-pointer transition-opacity" style="height:65%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">SOL Breakpoint? · OVER +6.5%</div>
+            </div>
+            <div class="group relative flex-1 bg-primary-fixed hover:opacity-80 cursor-pointer transition-opacity" style="height:30%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">Stablecoin 160B? · UNDER -3.0%</div>
+            </div>
+            <div class="group relative flex-1 bg-secondary hover:opacity-80 cursor-pointer transition-opacity" style="height:55%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">XRP SEC? · OVER +5.5%</div>
+            </div>
+            <div class="group relative flex-1 bg-primary-fixed hover:opacity-80 cursor-pointer transition-opacity" style="height:45%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">GOP Nominee? · UNDER -4.5%</div>
+            </div>
+            <div class="group relative flex-1 bg-secondary hover:opacity-80 cursor-pointer transition-opacity" style="height:25%">
+              <div class="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 hidden group-hover:block bg-surface-highest border border-surface-high px-2 py-1 font-mono text-[8px] whitespace-nowrap z-10">ADA Vasil? · OVER +2.5%</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Filter Panel - narrower -->
+    <div class="lg:col-span-4 bg-surface-container border border-surface-high p-4 lg:p-5 space-y-5">
+      <div class="font-mono text-[9px] text-outline uppercase tracking-widest">Filter Controls</div>
+
+      <div class="space-y-2">
+        <div class="flex justify-between font-mono text-[9px]">
+          <span class="text-outline uppercase">Min Gap</span>
+          <span class="text-primary-fixed" id="gap-v2">3%</span>
+        </div>
+        <input type="range" min="1" max="20" value="3" class="w-full h-0.5 bg-surface-highest appearance-none cursor-pointer accent-[#00fd87]"
+          oninput="document.getElementById('gap-v2').textContent=this.value+'%'"/>
+        <div class="flex justify-between font-mono text-[8px] text-outline">
+          <span>1%</span><span>10%</span><span>20%</span>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <div class="font-mono text-[9px] text-outline uppercase">Direction</div>
+        <div class="grid grid-cols-3 gap-1">
+          <button class="py-2 bg-primary-fixed text-black font-mono text-[9px] font-bold uppercase">ALL</button>
+          <button class="py-2 bg-surface-highest text-outline font-mono text-[9px] font-bold uppercase hover:text-on-surface transition-colors">OVER</button>
+          <button class="py-2 bg-surface-highest text-outline font-mono text-[9px] font-bold uppercase hover:text-on-surface transition-colors">UNDER</button>
+        </div>
+      </div>
+
+      <!-- Mini legend cards -->
+      <div class="space-y-2 pt-2 border-t border-surface-high">
+        <div class="font-mono text-[9px] text-outline uppercase">What these mean</div>
+        <div class="bg-surface-low border-l-2 border-primary-fixed px-3 py-2">
+          <div class="font-mono text-[9px] text-primary-fixed font-bold">UNDER</div>
+          <div class="font-mono text-[8px] text-outline mt-0.5">Yes + No &lt; 1.0 → buy both</div>
+        </div>
+        <div class="bg-surface-low border-l-2 border-secondary px-3 py-2">
+          <div class="font-mono text-[9px] text-secondary font-bold">OVER</div>
+          <div class="font-mono text-[8px] text-outline mt-0.5">Yes + No &gt; 1.0 → sell both</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ROW 3: RESULTS TABLE -->
+  <div class="border border-surface-high overflow-hidden">
+    <div class="bg-surface-container px-4 py-3 border-b border-surface-high flex justify-between items-center">
+      <span class="font-mono text-[9px] text-outline uppercase tracking-widest">Results — 5 Signals</span>
+      <div class="flex gap-2 text-outline">
+        <button class="hover:text-on-surface transition-colors p-1"><span class="material-symbols-outlined text-sm">filter_list</span></button>
+        <button class="hover:text-on-surface transition-colors p-1"><span class="material-symbols-outlined text-sm">download</span></button>
+      </div>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="w-full font-mono text-xs">
+        <thead>
+          <tr class="bg-surface-container border-b border-surface-highest text-[9px] uppercase text-outline">
+            <th class="px-4 py-3 text-left font-normal">Market</th>
+            <th class="px-4 py-3 text-right font-normal">GAP</th>
+            <th class="px-4 py-3 text-right font-normal hidden sm:table-cell">NET (−2%fee)</th>
+            <th class="px-4 py-3 text-right font-normal hidden md:table-cell">YES</th>
+            <th class="px-4 py-3 text-right font-normal hidden md:table-cell">NO</th>
+            <th class="px-4 py-3 text-right font-normal hidden md:table-cell">SUM</th>
+            <th class="px-4 py-3 text-center font-normal">DIR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer">
+            <td class="px-4 py-3 text-on-surface">Fed Rate Hike Sept 2024</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-7.0%</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+5.0%</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.890</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.040</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.930</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black">UNDER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container bg-surface-low hover:bg-surface-high transition-colors cursor-pointer">
+            <td class="px-4 py-3 text-on-surface">DOGE hits $1 before halving?</td>
+            <td class="px-4 py-3 text-right font-bold text-secondary">+8.0%</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+6.0%</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.550</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.530</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">1.080</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-secondary text-black text-[8px] font-black">OVER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer">
+            <td class="px-4 py-3 text-on-surface">ETH ETF Approved by August?</td>
+            <td class="px-4 py-3 text-right font-bold text-secondary">+5.0%</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+3.0%</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.681</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.344</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">1.025</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-secondary text-black text-[8px] font-black">OVER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container bg-surface-low hover:bg-surface-high transition-colors cursor-pointer">
+            <td class="px-4 py-3 text-on-surface">Solana Breakpoint Announcement?</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-4.0%</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed hidden sm:table-cell">+2.0%</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.220</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.740</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.960</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black">UNDER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer">
+            <td class="px-4 py-3 text-on-surface">Will BTC hit 100k by EOY?</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-3.0%</td>
+            <td class="px-4 py-3 text-right font-bold text-outline hidden sm:table-cell">+1.0%</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.450</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.520</td>
+            <td class="px-4 py-3 text-right text-on-surface-variant hidden md:table-cell">0.970</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black">UNDER</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/stitch/layout-3-split-pane.html
+++ b/stitch/layout-3-split-pane.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html class="dark" lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>POLYSCAN — Layout 3: Split Pane</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<script>
+tailwind.config = {
+  darkMode:"class",
+  theme:{ extend:{ colors:{
+    "primary-fixed":"#00fd87","primary-dim":"#00ed7e",
+    "surface":"#131313","surface-low":"#1c1b1b","surface-container":"#201f1f",
+    "surface-high":"#2a2a2a","surface-highest":"#353534","surface-dim":"#0e0e0e",
+    "on-surface":"#e5e2e1","on-surface-variant":"#b9cbb9",
+    "outline":"#849585","outline-variant":"#3b4b3d",
+    "secondary":"#ffb4ab","secondary-container":"#8d1d1e",
+  }, fontFamily:{ mono:['"JetBrains Mono"','monospace'], sg:['"Space Grotesk"','sans-serif'] },
+  borderRadius:{ DEFAULT:"0px", lg:"0px", xl:"0px", full:"9999px" } } }
+}
+</script>
+<style>
+* { box-sizing:border-box; }
+body { background:#131313; color:#e5e2e1; font-family:'Space Grotesk',sans-serif; -webkit-font-smoothing:antialiased; margin:0; overflow:hidden; height:100vh; }
+.material-symbols-outlined { font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24; display:inline-block; line-height:1; }
+::-webkit-scrollbar { width:4px; height:4px; }
+::-webkit-scrollbar-track { background:#131313; }
+::-webkit-scrollbar-thumb { background:#353534; }
+.selected-row { background:#201f1f !important; border-left: 2px solid #00fd87; }
+.selected-row td:first-child { padding-left: calc(1rem - 2px); }
+</style>
+</head>
+<body class="flex flex-col h-screen">
+
+<!-- HEADER -->
+<header class="flex items-center justify-between px-4 h-12 bg-surface-dim border-b border-surface-high flex-shrink-0">
+  <div class="flex items-center gap-2">
+    <span class="material-symbols-outlined text-primary-fixed text-base">terminal</span>
+    <span class="font-sg font-black text-primary-fixed uppercase tracking-tighter">POLYSCAN</span>
+  </div>
+  <div class="flex items-center gap-4">
+    <div class="hidden sm:flex gap-4 font-mono text-[9px] text-outline">
+      <span>1,243 scanned</span>
+      <span class="text-primary-fixed">7 gaps</span>
+      <span>06:45 UTC</span>
+    </div>
+    <button class="bg-primary-fixed text-black text-[9px] font-mono font-bold px-3 py-1.5 uppercase hover:bg-primary-dim transition-colors">SCAN</button>
+  </div>
+</header>
+
+<!-- FILTER BAR -->
+<div class="flex items-center gap-4 px-4 py-2 bg-surface-container border-b border-surface-high flex-shrink-0 flex-wrap gap-y-2">
+  <span class="font-mono text-[8px] text-outline uppercase">Filter:</span>
+  <div class="flex items-center gap-2">
+    <span class="font-mono text-[8px] text-outline">Min Gap</span>
+    <input type="range" min="1" max="20" value="3" class="w-24 h-0.5 bg-surface-highest appearance-none cursor-pointer accent-[#00fd87]"
+      oninput="document.getElementById('gap-v3').textContent=this.value+'%'"/>
+    <span class="font-mono text-[9px] text-primary-fixed w-8" id="gap-v3">3%</span>
+  </div>
+  <div class="flex bg-surface-highest font-mono text-[8px]">
+    <button class="px-2 py-1 bg-primary-fixed text-black font-bold uppercase">ALL</button>
+    <button class="px-2 py-1 text-outline hover:text-on-surface uppercase transition-colors">OVER</button>
+    <button class="px-2 py-1 text-outline hover:text-on-surface uppercase transition-colors">UNDER</button>
+  </div>
+  <span class="font-mono text-[8px] text-outline ml-auto">Click row for details →</span>
+</div>
+
+<!-- SPLIT PANE MAIN -->
+<div class="flex flex-1 overflow-hidden">
+
+  <!-- LEFT: Master List -->
+  <div class="w-full lg:w-2/5 border-r border-surface-high flex flex-col overflow-hidden">
+    <div class="overflow-y-auto flex-1">
+      <table class="w-full font-mono text-xs">
+        <thead class="sticky top-0 bg-surface-container border-b border-surface-high z-10">
+          <tr class="text-[9px] uppercase text-outline">
+            <th class="px-4 py-2 text-left font-normal">Market</th>
+            <th class="px-4 py-2 text-right font-normal">GAP</th>
+            <th class="px-4 py-2 text-center font-normal">DIR</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="selected-row border-b border-surface-container cursor-pointer" onclick="selectRow(this, 0)">
+            <td class="px-4 py-3 text-on-surface max-w-[200px] truncate">Fed Rate Hike Sept 2024</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-7.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black">UNDER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" onclick="selectRow(this, 1)">
+            <td class="px-4 py-3 text-on-surface max-w-[200px] truncate">DOGE hits $1 before halving?</td>
+            <td class="px-4 py-3 text-right font-bold text-secondary">+8.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-secondary text-black text-[8px] font-black">OVER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" onclick="selectRow(this, 2)">
+            <td class="px-4 py-3 text-on-surface max-w-[200px] truncate">ETH ETF Approved by August?</td>
+            <td class="px-4 py-3 text-right font-bold text-secondary">+5.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-secondary text-black text-[8px] font-black">OVER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" onclick="selectRow(this, 3)">
+            <td class="px-4 py-3 text-on-surface max-w-[200px] truncate">Solana Breakpoint Announcement?</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-4.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black">UNDER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" onclick="selectRow(this, 4)">
+            <td class="px-4 py-3 text-on-surface max-w-[200px] truncate">Will BTC hit 100k by EOY?</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-3.0%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black">UNDER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" onclick="selectRow(this, 5)">
+            <td class="px-4 py-3 text-on-surface max-w-[200px] truncate">Stablecoin Market Cap 160B?</td>
+            <td class="px-4 py-3 text-right font-bold text-primary-fixed">-4.5%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-primary-fixed text-black text-[8px] font-black">UNDER</span></td>
+          </tr>
+          <tr class="border-b border-surface-container hover:bg-surface-high transition-colors cursor-pointer" onclick="selectRow(this, 6)">
+            <td class="px-4 py-3 text-on-surface max-w-[200px] truncate">XRP SEC Case Resolved 2024?</td>
+            <td class="px-4 py-3 text-right font-bold text-secondary">+3.5%</td>
+            <td class="px-4 py-3 text-center"><span class="px-1.5 py-0.5 bg-secondary text-black text-[8px] font-black">OVER</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- RIGHT: Detail Panel -->
+  <div class="hidden lg:flex flex-col flex-1 overflow-y-auto" id="detail-panel">
+    <div class="p-5 space-y-5">
+
+      <!-- Market title -->
+      <div>
+        <div class="font-mono text-[9px] text-outline uppercase mb-1">Selected Market</div>
+        <div class="font-sg font-bold text-on-surface text-lg leading-tight" id="detail-title">Fed Rate Hike Sept 2024</div>
+        <div class="flex items-center gap-2 mt-1">
+          <span class="px-2 py-0.5 bg-primary-fixed text-black font-mono text-[9px] font-black">UNDER</span>
+          <span class="font-mono text-[9px] text-primary-fixed font-bold" id="detail-gap">-7.0% gap</span>
+        </div>
+      </div>
+
+      <!-- Price breakdown -->
+      <div class="bg-surface-container border border-surface-high p-4 space-y-3">
+        <div class="font-mono text-[9px] text-outline uppercase">Price Breakdown</div>
+        <div class="grid grid-cols-3 gap-3">
+          <div class="text-center">
+            <div class="font-mono text-[9px] text-outline uppercase mb-1">YES</div>
+            <div class="font-mono text-xl font-bold text-on-surface" id="detail-yes">0.890</div>
+            <div class="font-mono text-[8px] text-outline">midpoint</div>
+          </div>
+          <div class="text-center">
+            <div class="font-mono text-[9px] text-outline uppercase mb-1">NO</div>
+            <div class="font-mono text-xl font-bold text-on-surface" id="detail-no">0.040</div>
+            <div class="font-mono text-[8px] text-outline">midpoint</div>
+          </div>
+          <div class="text-center">
+            <div class="font-mono text-[9px] text-outline uppercase mb-1">SUM</div>
+            <div class="font-mono text-xl font-bold text-primary-fixed" id="detail-sum">0.930</div>
+            <div class="font-mono text-[8px] text-primary-fixed">vs 1.000</div>
+          </div>
+        </div>
+        <!-- Visual gap indicator -->
+        <div class="space-y-1">
+          <div class="flex justify-between font-mono text-[8px] text-outline">
+            <span>0.930</span><span>1.000 (target)</span>
+          </div>
+          <div class="h-2 bg-surface-highest relative">
+            <div class="h-full bg-primary-fixed" style="width:93%"></div>
+            <div class="absolute right-0 top-0 h-full border-r-2 border-dashed border-outline"></div>
+          </div>
+          <div class="font-mono text-[8px] text-primary-fixed">Gap: 7.0¢ below fair value</div>
+        </div>
+      </div>
+
+      <!-- Profit calc -->
+      <div class="bg-surface-container border border-surface-high p-4 space-y-3">
+        <div class="font-mono text-[9px] text-outline uppercase">Profit Calculator</div>
+        <div class="space-y-2">
+          <div class="flex justify-between font-mono text-[10px]">
+            <span class="text-outline">Raw gap</span>
+            <span class="text-on-surface font-bold">7.00%</span>
+          </div>
+          <div class="flex justify-between font-mono text-[10px]">
+            <span class="text-outline">Fee (2% × 2 sides)</span>
+            <span class="text-secondary">−2.00%</span>
+          </div>
+          <div class="border-t border-surface-high pt-2 flex justify-between font-mono text-[10px]">
+            <span class="text-outline font-bold">Net profit</span>
+            <span class="text-primary-fixed font-bold text-base">+5.00%</span>
+          </div>
+        </div>
+        <button onclick="window.open('#','_blank')" class="w-full py-2 bg-primary-fixed text-black font-mono text-[10px] font-bold uppercase hover:bg-primary-dim transition-colors mt-2">
+          View on Polymarket →
+        </button>
+      </div>
+
+      <!-- Mini chart sparkline -->
+      <div class="bg-surface-container border border-surface-high p-4">
+        <div class="font-mono text-[9px] text-outline uppercase mb-3">Gap Trend (Simulated)</div>
+        <div class="flex items-end gap-0.5 h-10">
+          <div class="flex-1 bg-primary-fixed opacity-30" style="height:40%"></div>
+          <div class="flex-1 bg-primary-fixed opacity-40" style="height:50%"></div>
+          <div class="flex-1 bg-primary-fixed opacity-50" style="height:55%"></div>
+          <div class="flex-1 bg-primary-fixed opacity-60" style="height:60%"></div>
+          <div class="flex-1 bg-primary-fixed opacity-70" style="height:65%"></div>
+          <div class="flex-1 bg-primary-fixed opacity-80" style="height:70%"></div>
+          <div class="flex-1 bg-primary-fixed opacity-90" style="height:80%"></div>
+          <div class="flex-1 bg-primary-fixed" style="height:100%"></div>
+        </div>
+        <div class="font-mono text-[8px] text-outline mt-1">Gap widening over last 8 scans</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mobile: detail as bottom sheet placeholder -->
+  <div class="lg:hidden fixed bottom-0 left-0 right-0 bg-surface-container border-t border-surface-high p-4 font-mono text-[10px] text-outline text-center">
+    ← Tap a row to see details (best on desktop)
+  </div>
+</div>
+
+<script>
+var details = [
+  { title:"Fed Rate Hike Sept 2024", dir:"UNDER", gap:"-7.0%", yes:"0.890", no:"0.040", sum:"0.930" },
+  { title:"DOGE hits $1 before halving?", dir:"OVER", gap:"+8.0%", yes:"0.550", no:"0.530", sum:"1.080" },
+  { title:"ETH ETF Approved by August?", dir:"OVER", gap:"+5.0%", yes:"0.681", no:"0.344", sum:"1.025" },
+  { title:"Solana Breakpoint Announcement?", dir:"UNDER", gap:"-4.0%", yes:"0.220", no:"0.740", sum:"0.960" },
+  { title:"Will BTC hit 100k by EOY?", dir:"UNDER", gap:"-3.0%", yes:"0.450", no:"0.520", sum:"0.970" },
+  { title:"Stablecoin Market Cap 160B?", dir:"UNDER", gap:"-4.5%", yes:"0.490", no:"0.465", sum:"0.955" },
+  { title:"XRP SEC Case Resolved 2024?", dir:"OVER", gap:"+3.5%", yes:"0.620", no:"0.415", sum:"1.035" },
+];
+function selectRow(row, idx){
+  document.querySelectorAll('tbody tr').forEach(function(r){ r.classList.remove('selected-row'); r.classList.add('hover:bg-surface-high'); });
+  row.classList.add('selected-row');
+  var d = details[idx];
+  document.getElementById('detail-title').textContent = d.title;
+  document.getElementById('detail-gap').textContent = d.gap + ' gap';
+  document.getElementById('detail-yes').textContent = d.yes;
+  document.getElementById('detail-no').textContent = d.no;
+  document.getElementById('detail-sum').textContent = d.sum;
+  document.getElementById('detail-gap').className = 'font-mono text-[9px] font-bold ' + (d.dir==='UNDER' ? 'text-primary-fixed' : 'text-secondary');
+}
+</script>
+</body>
+</html>

--- a/stitch/layout-4-live-feed.html
+++ b/stitch/layout-4-live-feed.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html class="dark" lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>POLYSCAN — Layout 4: Live Feed</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<script>
+tailwind.config = {
+  darkMode:"class",
+  theme:{ extend:{ colors:{
+    "primary-fixed":"#00fd87","primary-dim":"#00ed7e",
+    "surface":"#131313","surface-low":"#1c1b1b","surface-container":"#201f1f",
+    "surface-high":"#2a2a2a","surface-highest":"#353534","surface-dim":"#0e0e0e",
+    "on-surface":"#e5e2e1","on-surface-variant":"#b9cbb9",
+    "outline":"#849585","outline-variant":"#3b4b3d",
+    "secondary":"#ffb4ab","secondary-container":"#8d1d1e",
+  }, fontFamily:{ mono:['"JetBrains Mono"','monospace'], sg:['"Space Grotesk"','sans-serif'] },
+  borderRadius:{ DEFAULT:"0px", lg:"0px", xl:"0px", full:"9999px" } } }
+}
+</script>
+<style>
+* { box-sizing:border-box; }
+body { background:#131313; color:#e5e2e1; font-family:'Space Grotesk',sans-serif; -webkit-font-smoothing:antialiased; margin:0; }
+.material-symbols-outlined { font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24; display:inline-block; line-height:1; }
+::-webkit-scrollbar { width:4px; height:4px; }
+::-webkit-scrollbar-track { background:#131313; }
+::-webkit-scrollbar-thumb { background:#353534; }
+@keyframes slideIn {
+  from { opacity:0; transform:translateY(-12px); }
+  to { opacity:1; transform:translateY(0); }
+}
+.signal-card { animation: slideIn 0.3s ease-out; }
+@keyframes ticker {
+  0% { transform: translateX(100%); }
+  100% { transform: translateX(-100%); }
+}
+.ticker-inner { animation: ticker 25s linear infinite; }
+.bar-fill { transition: height 0.8s ease; }
+</style>
+</head>
+<body class="min-h-screen pb-20">
+
+<!-- HEADER -->
+<header class="flex items-center justify-between px-4 h-12 bg-surface-dim border-b border-surface-high sticky top-0 z-50">
+  <div class="flex items-center gap-2">
+    <span class="material-symbols-outlined text-primary-fixed text-base">terminal</span>
+    <span class="font-sg font-black text-primary-fixed uppercase tracking-tighter">POLYSCAN</span>
+  </div>
+  <div class="flex items-center gap-3">
+    <div class="flex items-center gap-1.5">
+      <div class="w-1.5 h-1.5 rounded-full bg-primary-fixed animate-pulse"></div>
+      <span class="font-mono text-[9px] text-primary-fixed">LIVE FEED</span>
+    </div>
+    <button onclick="addFakeSignal()" class="bg-primary-fixed text-black text-[9px] font-mono font-bold px-3 py-1.5 uppercase hover:bg-primary-dim transition-colors">
+      SCAN NOW
+    </button>
+  </div>
+</header>
+
+<!-- TICKER TAPE -->
+<div class="bg-surface-container border-b border-surface-high overflow-hidden h-7 flex items-center">
+  <div class="font-mono text-[9px] text-outline px-2 border-r border-surface-high h-full flex items-center bg-surface-dim whitespace-nowrap">⚡ SIGNALS</div>
+  <div class="flex-1 overflow-hidden relative">
+    <div class="ticker-inner whitespace-nowrap font-mono text-[9px] flex items-center gap-8">
+      <span class="text-primary-fixed">BTC 100k ↓ -3.0%</span>
+      <span class="text-secondary">ETH ETF ↑ +5.0%</span>
+      <span class="text-primary-fixed">FED HIKE ↓ -7.0%</span>
+      <span class="text-secondary">DOGE $1 ↑ +8.0%</span>
+      <span class="text-primary-fixed">SOL BREAK ↓ -4.0%</span>
+      <span class="text-outline">XRP SEC ↑ +3.5%</span>
+      <span class="text-primary-fixed">STABLE 160B ↓ -4.5%</span>
+    </div>
+  </div>
+</div>
+
+<!-- STATS ROW -->
+<div class="grid grid-cols-3 gap-px bg-surface-high">
+  <div class="bg-surface-dim px-4 py-3">
+    <div class="font-mono text-[8px] text-outline uppercase">Scanned</div>
+    <div class="font-mono text-xl font-bold text-on-surface">1,243</div>
+  </div>
+  <div class="bg-surface-dim px-4 py-3">
+    <div class="font-mono text-[8px] text-outline uppercase">Live Signals</div>
+    <div class="font-mono text-xl font-bold text-primary-fixed" id="signal-count">7</div>
+  </div>
+  <div class="bg-surface-dim px-4 py-3">
+    <div class="font-mono text-[8px] text-outline uppercase">Last Update</div>
+    <div class="font-mono text-xl font-bold text-on-surface">06:45<span class="text-xs text-outline ml-1">UTC</span></div>
+  </div>
+</div>
+
+<!-- FILTER ROW -->
+<div class="flex items-center gap-3 px-4 py-2 bg-surface-container border-b border-surface-high sticky top-12 z-40 flex-wrap gap-y-2">
+  <div class="flex bg-surface-highest font-mono text-[8px]">
+    <button class="px-3 py-1.5 bg-primary-fixed text-black font-bold uppercase">ALL</button>
+    <button class="px-3 py-1.5 text-outline hover:text-on-surface uppercase transition-colors">OVER</button>
+    <button class="px-3 py-1.5 text-outline hover:text-on-surface uppercase transition-colors">UNDER</button>
+  </div>
+  <div class="flex items-center gap-2">
+    <span class="font-mono text-[8px] text-outline">Min</span>
+    <input type="range" min="1" max="20" value="3" class="w-20 h-0.5 bg-surface-highest appearance-none cursor-pointer accent-[#00fd87]"
+      oninput="document.getElementById('gap-v4').textContent=this.value+'%'"/>
+    <span class="font-mono text-[9px] text-primary-fixed" id="gap-v4">3%</span>
+  </div>
+  <div class="flex gap-2 ml-auto font-mono text-[8px] text-outline">
+    <button class="flex items-center gap-1 hover:text-on-surface transition-colors"><span class="material-symbols-outlined text-sm">sort</span>BY GAP</button>
+    <button class="flex items-center gap-1 hover:text-on-surface transition-colors"><span class="material-symbols-outlined text-sm">schedule</span>BY TIME</button>
+  </div>
+</div>
+
+<!-- SIGNAL CARDS FEED -->
+<div class="p-4 space-y-3 max-w-2xl mx-auto lg:max-w-none" id="feed">
+
+  <!-- Card: UNDER (high gap) -->
+  <div class="signal-card bg-surface-container border border-surface-high hover:border-primary-fixed transition-colors cursor-pointer group" onclick="window.open('#','_blank')">
+    <div class="flex items-start gap-4 p-4">
+      <!-- Mini sparkline bars -->
+      <div class="flex items-end gap-px h-10 w-12 flex-shrink-0 self-end">
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-30" style="height:40%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-50" style="height:55%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-70" style="height:65%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed" style="height:85%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed" style="height:100%"></div>
+      </div>
+      <!-- Content -->
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="px-1.5 py-0.5 bg-primary-fixed text-black font-mono text-[8px] font-black uppercase">UNDER</span>
+          <span class="font-mono text-[8px] text-outline">06:45 UTC</span>
+          <span class="font-mono text-[8px] text-outline ml-auto">↑ widening</span>
+        </div>
+        <div class="font-sg font-semibold text-on-surface text-sm truncate group-hover:text-primary-fixed transition-colors">
+          Fed Rate Hike Sept 2024
+        </div>
+        <div class="flex items-center gap-4 mt-2 font-mono text-[9px]">
+          <span class="text-outline">YES <span class="text-on-surface-variant">0.890</span></span>
+          <span class="text-outline">NO <span class="text-on-surface-variant">0.040</span></span>
+          <span class="text-outline">SUM <span class="text-primary-fixed font-bold">0.930</span></span>
+        </div>
+      </div>
+      <!-- Gap badge -->
+      <div class="flex-shrink-0 text-right">
+        <div class="font-mono text-2xl font-bold text-primary-fixed leading-none">7.0<span class="text-sm">%</span></div>
+        <div class="font-mono text-[8px] text-outline mt-0.5">net +5.0%</div>
+        <div class="font-mono text-[8px] text-primary-fixed mt-1 opacity-0 group-hover:opacity-100 transition-opacity">Open →</div>
+      </div>
+    </div>
+    <!-- Bottom bar: gap visualizer -->
+    <div class="h-0.5 bg-surface-highest">
+      <div class="h-full bg-primary-fixed" style="width:70%"></div>
+    </div>
+  </div>
+
+  <!-- Card: OVER (high gap) -->
+  <div class="signal-card bg-surface-container border border-surface-high hover:border-secondary transition-colors cursor-pointer group" onclick="window.open('#','_blank')">
+    <div class="flex items-start gap-4 p-4">
+      <div class="flex items-end gap-px h-10 w-12 flex-shrink-0 self-end">
+        <div class="flex-1 bar-fill bg-secondary opacity-20" style="height:30%"></div>
+        <div class="flex-1 bar-fill bg-secondary opacity-40" style="height:60%"></div>
+        <div class="flex-1 bar-fill bg-secondary opacity-60" style="height:70%"></div>
+        <div class="flex-1 bar-fill bg-secondary opacity-80" style="height:85%"></div>
+        <div class="flex-1 bar-fill bg-secondary" style="height:100%"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="px-1.5 py-0.5 bg-secondary text-black font-mono text-[8px] font-black uppercase">OVER</span>
+          <span class="font-mono text-[8px] text-outline">06:44 UTC</span>
+          <span class="font-mono text-[8px] text-secondary ml-auto">↑ new high</span>
+        </div>
+        <div class="font-sg font-semibold text-on-surface text-sm truncate group-hover:text-secondary transition-colors">
+          DOGE hits $1 before halving?
+        </div>
+        <div class="flex items-center gap-4 mt-2 font-mono text-[9px]">
+          <span class="text-outline">YES <span class="text-on-surface-variant">0.550</span></span>
+          <span class="text-outline">NO <span class="text-on-surface-variant">0.530</span></span>
+          <span class="text-outline">SUM <span class="text-secondary font-bold">1.080</span></span>
+        </div>
+      </div>
+      <div class="flex-shrink-0 text-right">
+        <div class="font-mono text-2xl font-bold text-secondary leading-none">8.0<span class="text-sm">%</span></div>
+        <div class="font-mono text-[8px] text-outline mt-0.5">net +6.0%</div>
+        <div class="font-mono text-[8px] text-secondary mt-1 opacity-0 group-hover:opacity-100 transition-opacity">Open →</div>
+      </div>
+    </div>
+    <div class="h-0.5 bg-surface-highest">
+      <div class="h-full bg-secondary" style="width:80%"></div>
+    </div>
+  </div>
+
+  <!-- Card: OVER -->
+  <div class="signal-card bg-surface-container border border-surface-high hover:border-secondary transition-colors cursor-pointer group" onclick="window.open('#','_blank')">
+    <div class="flex items-start gap-4 p-4">
+      <div class="flex items-end gap-px h-10 w-12 flex-shrink-0 self-end">
+        <div class="flex-1 bar-fill bg-secondary opacity-30" style="height:45%"></div>
+        <div class="flex-1 bar-fill bg-secondary opacity-50" style="height:55%"></div>
+        <div class="flex-1 bar-fill bg-secondary opacity-65" style="height:60%"></div>
+        <div class="flex-1 bar-fill bg-secondary opacity-80" style="height:70%"></div>
+        <div class="flex-1 bar-fill bg-secondary" style="height:100%"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="px-1.5 py-0.5 bg-secondary text-black font-mono text-[8px] font-black uppercase">OVER</span>
+          <span class="font-mono text-[8px] text-outline">06:44 UTC</span>
+        </div>
+        <div class="font-sg font-semibold text-on-surface text-sm truncate group-hover:text-secondary transition-colors">
+          ETH ETF Approved by August?
+        </div>
+        <div class="flex items-center gap-4 mt-2 font-mono text-[9px]">
+          <span class="text-outline">YES <span class="text-on-surface-variant">0.681</span></span>
+          <span class="text-outline">NO <span class="text-on-surface-variant">0.344</span></span>
+          <span class="text-outline">SUM <span class="text-secondary font-bold">1.025</span></span>
+        </div>
+      </div>
+      <div class="flex-shrink-0 text-right">
+        <div class="font-mono text-2xl font-bold text-secondary leading-none">5.0<span class="text-sm">%</span></div>
+        <div class="font-mono text-[8px] text-outline mt-0.5">net +3.0%</div>
+        <div class="font-mono text-[8px] text-secondary mt-1 opacity-0 group-hover:opacity-100 transition-opacity">Open →</div>
+      </div>
+    </div>
+    <div class="h-0.5 bg-surface-highest"><div class="h-full bg-secondary" style="width:50%"></div></div>
+  </div>
+
+  <!-- Card: UNDER -->
+  <div class="signal-card bg-surface-container border border-surface-high hover:border-primary-fixed transition-colors cursor-pointer group" onclick="window.open('#','_blank')">
+    <div class="flex items-start gap-4 p-4">
+      <div class="flex items-end gap-px h-10 w-12 flex-shrink-0 self-end">
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-40" style="height:35%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-60" style="height:50%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-75" style="height:55%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-85" style="height:65%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed" style="height:100%"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="px-1.5 py-0.5 bg-primary-fixed text-black font-mono text-[8px] font-black uppercase">UNDER</span>
+          <span class="font-mono text-[8px] text-outline">06:43 UTC</span>
+        </div>
+        <div class="font-sg font-semibold text-on-surface text-sm truncate group-hover:text-primary-fixed transition-colors">
+          Solana Breakpoint Announcement?
+        </div>
+        <div class="flex items-center gap-4 mt-2 font-mono text-[9px]">
+          <span class="text-outline">YES <span class="text-on-surface-variant">0.220</span></span>
+          <span class="text-outline">NO <span class="text-on-surface-variant">0.740</span></span>
+          <span class="text-outline">SUM <span class="text-primary-fixed font-bold">0.960</span></span>
+        </div>
+      </div>
+      <div class="flex-shrink-0 text-right">
+        <div class="font-mono text-2xl font-bold text-primary-fixed leading-none">4.0<span class="text-sm">%</span></div>
+        <div class="font-mono text-[8px] text-outline mt-0.5">net +2.0%</div>
+        <div class="font-mono text-[8px] text-primary-fixed mt-1 opacity-0 group-hover:opacity-100 transition-opacity">Open →</div>
+      </div>
+    </div>
+    <div class="h-0.5 bg-surface-highest"><div class="h-full bg-primary-fixed" style="width:40%"></div></div>
+  </div>
+
+  <!-- Card: UNDER (low gap) -->
+  <div class="signal-card bg-surface-container border border-surface-high hover:border-primary-fixed transition-colors cursor-pointer group opacity-70" onclick="window.open('#','_blank')">
+    <div class="flex items-start gap-4 p-4">
+      <div class="flex items-end gap-px h-10 w-12 flex-shrink-0 self-end">
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-20" style="height:25%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-30" style="height:30%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-40" style="height:35%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed opacity-55" style="height:40%"></div>
+        <div class="flex-1 bar-fill bg-primary-fixed" style="height:100%"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="px-1.5 py-0.5 bg-primary-fixed text-black font-mono text-[8px] font-black uppercase">UNDER</span>
+          <span class="font-mono text-[8px] text-outline">06:42 UTC</span>
+          <span class="font-mono text-[8px] text-outline ml-auto">low priority</span>
+        </div>
+        <div class="font-sg font-semibold text-on-surface text-sm truncate">Will BTC hit 100k by EOY?</div>
+        <div class="flex items-center gap-4 mt-2 font-mono text-[9px]">
+          <span class="text-outline">YES <span class="text-on-surface-variant">0.450</span></span>
+          <span class="text-outline">NO <span class="text-on-surface-variant">0.520</span></span>
+          <span class="text-outline">SUM <span class="text-primary-fixed font-bold">0.970</span></span>
+        </div>
+      </div>
+      <div class="flex-shrink-0 text-right">
+        <div class="font-mono text-2xl font-bold text-primary-fixed leading-none">3.0<span class="text-sm">%</span></div>
+        <div class="font-mono text-[8px] text-outline mt-0.5">net +1.0%</div>
+      </div>
+    </div>
+    <div class="h-0.5 bg-surface-highest"><div class="h-full bg-primary-fixed" style="width:30%"></div></div>
+  </div>
+
+</div>
+
+<!-- New signal injection -->
+<script>
+var fakeSignals = [
+  { dir:"OVER", title:"ADA Vasil Fork Launch?", yes:"0.610", no:"0.440", sum:"1.050", gap:"5.0", net:"3.0", color:"secondary" },
+  { dir:"UNDER", title:"XRP vs SEC Settled 2024?", yes:"0.380", no:"0.580", sum:"0.960", gap:"4.0", net:"2.0", color:"primary-fixed" },
+];
+var fi = 0;
+function addFakeSignal(){
+  var d = fakeSignals[fi % fakeSignals.length]; fi++;
+  var isUnder = d.dir==="UNDER";
+  var color = isUnder ? "#00fd87" : "#ffb4ab";
+  var card = document.createElement("div");
+  card.className = "signal-card bg-surface-container border border-surface-high hover:border-"+d.color+" transition-colors cursor-pointer group";
+  card.innerHTML = `
+    <div class="flex items-start gap-4 p-4">
+      <div class="flex items-end gap-px h-10 w-12 flex-shrink-0 self-end">
+        <div class="flex-1 bg-[${color}] opacity-50" style="height:50%"></div>
+        <div class="flex-1 bg-[${color}] opacity-70" style="height:70%"></div>
+        <div class="flex-1 bg-[${color}]" style="height:100%"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="px-1.5 py-0.5 font-mono text-[8px] font-black uppercase" style="background:${color};color:black">${d.dir}</span>
+          <span class="font-mono text-[8px] text-outline">NEW</span>
+          <span class="font-mono text-[8px] text-primary-fixed ml-auto animate-pulse">⚡ just now</span>
+        </div>
+        <div class="font-sg font-semibold text-on-surface text-sm truncate">${d.title}</div>
+        <div class="flex items-center gap-4 mt-2 font-mono text-[9px]">
+          <span class="text-outline">YES <span class="text-on-surface-variant">${d.yes}</span></span>
+          <span class="text-outline">NO <span class="text-on-surface-variant">${d.no}</span></span>
+          <span class="text-outline">SUM <span style="color:${color}" class="font-bold">${d.sum}</span></span>
+        </div>
+      </div>
+      <div class="flex-shrink-0 text-right">
+        <div class="font-mono text-2xl font-bold leading-none" style="color:${color}">${d.gap}<span class="text-sm">%</span></div>
+        <div class="font-mono text-[8px] text-outline mt-0.5">net +${d.net}%</div>
+      </div>
+    </div>
+    <div class="h-0.5 bg-surface-highest"><div class="h-full" style="background:${color};width:${d.gap*10}%"></div></div>
+  `;
+  var feed = document.getElementById('feed');
+  feed.insertBefore(card, feed.firstChild);
+  var cnt = document.getElementById('signal-count');
+  cnt.textContent = parseInt(cnt.textContent) + 1;
+}
+</script>
+</body>
+</html>

--- a/stitch/layout-5-minimal-command.html
+++ b/stitch/layout-5-minimal-command.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html class="dark" lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>POLYSCAN — Layout 5: Minimal Command</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<style>
+* { box-sizing:border-box; }
+body { background:#0a0a0a; color:#c8c8c8; font-family:'JetBrains Mono',monospace; -webkit-font-smoothing:antialiased; margin:0; font-size:12px; }
+.material-symbols-outlined { font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24; display:inline-block; line-height:1; }
+::-webkit-scrollbar { width:4px; height:4px; }
+::-webkit-scrollbar-track { background:#0a0a0a; }
+::-webkit-scrollbar-thumb { background:#2a2a2a; }
+a, button { cursor:pointer; }
+.green { color:#00fd87; }
+.red { color:#ff6b6b; }
+.dim { color:#555; }
+.row:hover td { background:#111 !important; }
+.sort-active { color:#00fd87; }
+input[type=range] { accent-color:#00fd87; }
+</style>
+</head>
+<body class="min-h-screen">
+
+<!-- ONE-LINE HEADER -->
+<div class="flex items-center justify-between px-4 py-2 border-b border-[#1a1a1a] bg-[#050505]">
+  <div class="flex items-center gap-4">
+    <span class="green font-bold tracking-wider">POLYSCAN</span>
+    <span class="dim">|</span>
+    <span class="dim">arbitrage scanner</span>
+    <span class="dim">|</span>
+    <span class="green">● LIVE</span>
+  </div>
+  <div class="flex items-center gap-6 dim text-[11px]">
+    <span>1,243 markets</span>
+    <span class="green">7 signals</span>
+    <span>last: 06:45 UTC</span>
+    <button onclick="runScan()" id="scanbtn" class="green border border-[#00fd8755] px-3 py-1 hover:bg-[#00fd8711] transition-colors uppercase tracking-widest text-[10px]">
+      [scan]
+    </button>
+  </div>
+</div>
+
+<!-- INLINE FILTER — one line, keyboard friendly -->
+<div class="flex items-center gap-6 px-4 py-2 border-b border-[#151515] bg-[#080808] flex-wrap gap-y-2">
+  <span class="dim">&gt;</span>
+  <div class="flex items-center gap-2">
+    <label class="dim text-[10px] uppercase">gap≥</label>
+    <input type="range" min="1" max="20" value="3" class="w-24 h-px cursor-pointer"
+      oninput="document.getElementById('gv5').textContent=this.value+'%';filterTable(this.value,'gv5')"/>
+    <span class="green text-[10px]" id="gv5">3%</span>
+  </div>
+  <div class="flex items-center gap-1 text-[10px]">
+    <span class="dim">dir:</span>
+    <button onclick="setDir5('ALL',this)" class="dir5 green px-1" data-dir="ALL">[ALL]</button>
+    <button onclick="setDir5('OVER',this)" class="dir5 dim px-1 hover:text-[#c8c8c8]" data-dir="OVER">[OVER]</button>
+    <button onclick="setDir5('UNDER',this)" class="dir5 dim px-1 hover:text-[#c8c8c8]" data-dir="UNDER">[UNDER]</button>
+  </div>
+  <div class="ml-auto flex items-center gap-4 dim text-[10px]">
+    <button class="hover:text-[#c8c8c8] transition-colors" onclick="sortToggle('gap')">[sort: gap ↓]</button>
+    <button class="hover:text-[#c8c8c8] transition-colors">[export csv]</button>
+    <span id="result-count-5" class="green">5 results</span>
+  </div>
+</div>
+
+<!-- FULL-WIDTH TABLE — no decorations, maximum data density -->
+<div class="overflow-x-auto">
+  <table class="w-full border-collapse text-[11px]" id="main-table-5">
+    <thead>
+      <tr class="border-b border-[#1a1a1a] bg-[#080808]">
+        <th class="px-4 py-2 text-left font-normal dim uppercase text-[9px] tracking-widest cursor-pointer hover:text-[#c8c8c8]" onclick="sortToggle('market')"># MARKET</th>
+        <th class="px-4 py-2 text-right font-normal dim uppercase text-[9px] tracking-widest cursor-pointer hover:text-[#c8c8c8] sort-active" onclick="sortToggle('gap')">GAP ↓</th>
+        <th class="px-4 py-2 text-right font-normal dim uppercase text-[9px] tracking-widest cursor-pointer hover:text-[#c8c8c8]" onclick="sortToggle('net')">NET</th>
+        <th class="px-4 py-2 text-right font-normal dim uppercase text-[9px] tracking-widest hidden sm:table-cell">YES</th>
+        <th class="px-4 py-2 text-right font-normal dim uppercase text-[9px] tracking-widest hidden sm:table-cell">NO</th>
+        <th class="px-4 py-2 text-right font-normal dim uppercase text-[9px] tracking-widest hidden sm:table-cell">SUM</th>
+        <th class="px-4 py-2 text-center font-normal dim uppercase text-[9px] tracking-widest">DIR</th>
+        <th class="px-4 py-2 text-right font-normal dim uppercase text-[9px] tracking-widest hidden md:table-cell">LINK</th>
+      </tr>
+    </thead>
+    <tbody id="tbody5">
+      <!-- rows -->
+      <tr class="row border-b border-[#111] cursor-pointer" data-dir="UNDER" data-gap="7" data-net="5" onclick="openMkt(this)">
+        <td class="px-4 py-2.5"><span class="dim mr-3">01</span><span class="text-[#e0e0e0]">Fed Rate Hike Sept 2024</span></td>
+        <td class="px-4 py-2.5 text-right green font-bold">-7.0%</td>
+        <td class="px-4 py-2.5 text-right green font-bold">+5.0%</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.890</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.040</td>
+        <td class="px-4 py-2.5 text-right green hidden sm:table-cell">0.930</td>
+        <td class="px-4 py-2.5 text-center"><span class="green">[UNDER]</span></td>
+        <td class="px-4 py-2.5 text-right hidden md:table-cell"><a class="dim hover:green transition-colors" href="#" onclick="event.stopPropagation()">[open ↗]</a></td>
+      </tr>
+      <tr class="row border-b border-[#111] cursor-pointer" data-dir="OVER" data-gap="8" data-net="6" onclick="openMkt(this)">
+        <td class="px-4 py-2.5"><span class="dim mr-3">02</span><span class="text-[#e0e0e0]">DOGE hits $1 before halving?</span></td>
+        <td class="px-4 py-2.5 text-right red font-bold">+8.0%</td>
+        <td class="px-4 py-2.5 text-right green font-bold">+6.0%</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.550</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.530</td>
+        <td class="px-4 py-2.5 text-right red hidden sm:table-cell">1.080</td>
+        <td class="px-4 py-2.5 text-center"><span class="red">[OVER]</span></td>
+        <td class="px-4 py-2.5 text-right hidden md:table-cell"><a class="dim hover:green transition-colors" href="#" onclick="event.stopPropagation()">[open ↗]</a></td>
+      </tr>
+      <tr class="row border-b border-[#111] cursor-pointer" data-dir="OVER" data-gap="5" data-net="3" onclick="openMkt(this)">
+        <td class="px-4 py-2.5"><span class="dim mr-3">03</span><span class="text-[#e0e0e0]">ETH ETF Approved by August?</span></td>
+        <td class="px-4 py-2.5 text-right red font-bold">+5.0%</td>
+        <td class="px-4 py-2.5 text-right green font-bold">+3.0%</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.681</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.344</td>
+        <td class="px-4 py-2.5 text-right red hidden sm:table-cell">1.025</td>
+        <td class="px-4 py-2.5 text-center"><span class="red">[OVER]</span></td>
+        <td class="px-4 py-2.5 text-right hidden md:table-cell"><a class="dim hover:green transition-colors" href="#" onclick="event.stopPropagation()">[open ↗]</a></td>
+      </tr>
+      <tr class="row border-b border-[#111] cursor-pointer" data-dir="UNDER" data-gap="4" data-net="2" onclick="openMkt(this)">
+        <td class="px-4 py-2.5"><span class="dim mr-3">04</span><span class="text-[#e0e0e0]">Solana Breakpoint Announcement?</span></td>
+        <td class="px-4 py-2.5 text-right green font-bold">-4.0%</td>
+        <td class="px-4 py-2.5 text-right green font-bold">+2.0%</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.220</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.740</td>
+        <td class="px-4 py-2.5 text-right green hidden sm:table-cell">0.960</td>
+        <td class="px-4 py-2.5 text-center"><span class="green">[UNDER]</span></td>
+        <td class="px-4 py-2.5 text-right hidden md:table-cell"><a class="dim hover:green transition-colors" href="#" onclick="event.stopPropagation()">[open ↗]</a></td>
+      </tr>
+      <tr class="row border-b border-[#111] cursor-pointer" data-dir="UNDER" data-gap="3" data-net="1" onclick="openMkt(this)">
+        <td class="px-4 py-2.5"><span class="dim mr-3">05</span><span class="text-[#e0e0e0]">Will BTC hit 100k by EOY?</span></td>
+        <td class="px-4 py-2.5 text-right green font-bold">-3.0%</td>
+        <td class="px-4 py-2.5 text-right dim">+1.0%</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.450</td>
+        <td class="px-4 py-2.5 text-right dim hidden sm:table-cell">0.520</td>
+        <td class="px-4 py-2.5 text-right green hidden sm:table-cell">0.970</td>
+        <td class="px-4 py-2.5 text-center"><span class="green">[UNDER]</span></td>
+        <td class="px-4 py-2.5 text-right hidden md:table-cell"><a class="dim hover:green transition-colors" href="#" onclick="event.stopPropagation()">[open ↗]</a></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- MINIMAL STATUS BAR -->
+<div class="fixed bottom-0 left-0 right-0 flex justify-between items-center px-4 py-1.5 bg-[#050505] border-t border-[#151515] text-[9px] dim">
+  <span>polyscan v1.0-alpha · polymarket clob api</span>
+  <span class="flex items-center gap-3">
+    <span>fee: 2%/side</span>
+    <span>threshold: 3%</span>
+    <span class="green">● connected</span>
+  </span>
+</div>
+
+<script>
+var activeDir5 = 'ALL';
+var minGap5 = 3;
+
+function filterTable(){
+  minGap5 = parseInt(document.getElementById('gv5').textContent);
+  var rows = document.querySelectorAll('#tbody5 tr');
+  var shown = 0;
+  rows.forEach(function(row, i){
+    var dir = row.dataset.dir;
+    var gap = parseInt(row.dataset.gap);
+    var ok = (activeDir5==='ALL' || dir===activeDir5) && gap >= minGap5;
+    row.style.display = ok ? '' : 'none';
+    if(ok){ row.querySelector('.dim').textContent = String(++shown).padStart(2,'0') + ' '; }
+  });
+  document.getElementById('result-count-5').textContent = shown + ' results';
+}
+
+function setDir5(dir, btn){
+  activeDir5 = dir;
+  document.querySelectorAll('.dir5').forEach(function(b){
+    b.className = 'dir5 dim px-1 hover:text-[#c8c8c8]';
+  });
+  btn.className = 'dir5 green px-1';
+  filterTable();
+}
+
+document.querySelector('input[type=range]').addEventListener('input', function(){
+  minGap5 = parseInt(this.value);
+  filterTable();
+});
+
+function sortToggle(key){ /* demo only */ }
+function openMkt(row){ window.open('#','_blank'); }
+function runScan(){
+  var btn = document.getElementById('scanbtn');
+  btn.textContent = '[scanning...]';
+  btn.classList.add('animate-pulse');
+  setTimeout(function(){
+    btn.textContent = '[scan]';
+    btn.classList.remove('animate-pulse');
+  }, 2000);
+}
+</script>
+</body>
+</html>

--- a/stitch/scanner-desktop.html
+++ b/stitch/scanner-desktop.html
@@ -1,383 +1,587 @@
 <!DOCTYPE html>
-
-<html class="dark" lang="en"><head>
+<html class="dark" lang="en">
+<head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>POLYSCAN // TERMINAL_CORE</title>
+<title>POLYSCAN — Desktop</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;700&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
 <style>
-        body {
-            background-color: #0e0e0e;
-            color: #e5e2e1;
-            font-family: 'Space Grotesk', sans-serif;
-            margin: 0;
-            overflow-x: hidden;
-        }
-        .font-mono { font-family: 'JetBrains Mono', monospace; }
-        .font-space-grotesk { font-family: 'Space Grotesk', sans-serif; }
-        
-        /* Scanline Effect */
-        .scanlines {
-            position: fixed;
-            top: 0; left: 0; width: 100%; height: 100%;
-            background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.1) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.02), rgba(0, 255, 0, 0.01), rgba(0, 0, 255, 0.02));
-            background-size: 100% 2px, 3px 100%;
-            pointer-events: none;
-            z-index: 50;
-        }
+* { box-sizing:border-box; margin:0; padding:0; }
+body {
+  background:#0e0d14;
+  color:#e5e2e1;
+  font-family:'JetBrains Mono',monospace;
+  -webkit-font-smoothing:antialiased;
+  overflow-x:hidden;
+  min-height:100vh;
+}
+.material-symbols-outlined { font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24; display:inline-block; line-height:1; }
+::-webkit-scrollbar { width:4px; height:4px; }
+::-webkit-scrollbar-track { background:#0e0d14; }
+::-webkit-scrollbar-thumb { background:#3d3b50; border-radius:2px; }
 
-        /* Kinetic Glow for Active Elements */
-        .active-glow {
-            box-shadow: 0 0 10px rgba(0, 253, 135, 0.2);
-        }
+/* Ticker animation */
+@keyframes ticker { 0%{transform:translateX(0)} 100%{transform:translateX(-50%)} }
+.ticker-inner { animation:ticker 30s linear infinite; display:inline-flex; gap:3rem; white-space:nowrap; }
 
-        ::-webkit-scrollbar { width: 4px; }
-        ::-webkit-scrollbar-track { background: #0e0e0e; }
-        ::-webkit-scrollbar-thumb { background: #353534; }
-    </style>
-<script id="tailwind-config">
-        tailwind.config = {
-            darkMode: "class",
-            theme: {
-                extend: {
-                    colors: {
-                        "secondary-fixed-dim": "#ffb3ad",
-                        "surface-container-lowest": "#0e0e0e",
-                        "on-secondary-fixed-variant": "#8a1b1c",
-                        "secondary-fixed": "#ffdad6",
-                        "surface-container-high": "#2a2a2a",
-                        "inverse-primary": "#006d37",
-                        "on-primary-fixed": "#00210c",
-                        "secondary": "#ffb3ad",
-                        "on-secondary-fixed": "#410003",
-                        "tertiary-fixed-dim": "#e7c267",
-                        "surface-variant": "#353534",
-                        "on-tertiary": "#3e2e00",
-                        "on-tertiary-container": "#795d05",
-                        "on-tertiary-fixed-variant": "#5a4400",
-                        "tertiary-container": "#ffd87a",
-                        "surface-tint": "#00e479",
-                        "on-surface": "#e5e2e1",
-                        "surface-container-highest": "#353534",
-                        "on-secondary": "#680009",
-                        "on-primary-fixed-variant": "#005228",
-                        "surface-container": "#201f1f",
-                        "surface-container-low": "#1c1b1b",
-                        "primary-fixed": "#60ff99",
-                        "surface-bright": "#3a3939",
-                        "outline-variant": "#3b4b3d",
-                        "primary-container": "#00fd87",
-                        "on-secondary-container": "#ff9e97",
-                        "primary-fixed-dim": "#00e479",
-                        "on-primary": "#003919",
-                        "on-background": "#e5e2e1",
-                        "outline": "#849585",
-                        "inverse-surface": "#e5e2e1",
-                        "on-error": "#690005",
-                        "on-tertiary-fixed": "#251a00",
-                        "secondary-container": "#8d1d1e",
-                        "surface-dim": "#131313",
-                        "primary": "#eaffe9",
-                        "error-container": "#93000a",
-                        "on-surface-variant": "#b9cbb9",
-                        "tertiary": "#fff8f0",
-                        "surface": "#131313",
-                        "on-error-container": "#ffdad6",
-                        "inverse-on-surface": "#313030",
-                        "on-primary-container": "#007038",
-                        "error": "#ffb4ab",
-                        "background": "#131313",
-                        "tertiary-fixed": "#ffdf96"
-                    },
-                    fontFamily: {
-                        "headline": ["Space Grotesk"],
-                        "body": ["Inter"],
-                        "label": ["Space Grotesk"]
-                    },
-                    borderRadius: {"DEFAULT": "0px", "lg": "0px", "xl": "0px", "full": "9999px"},
-                },
-            },
-        }
-    </script>
+/* Card slide-in */
+@keyframes slideIn { from{opacity:0;transform:translateY(-6px)} to{opacity:1;transform:translateY(0)} }
+.signal-card { animation:slideIn 0.2s ease-out; }
+
+/* Gap bar */
+.gap-bar { transition:width 0.6s ease; }
+
+/* Scan lines overlay */
+.scanlines {
+  position:fixed; top:0; left:0; width:100%; height:100%; pointer-events:none; z-index:999;
+  background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.03) 2px, rgba(0,0,0,0.03) 4px);
+}
+
+/* Active nav item */
+.nav-active {
+  background: linear-gradient(90deg, rgba(252,114,255,0.12) 0%, transparent 100%);
+  border-left: 2px solid #fc72ff;
+  color: #fc72ff !important;
+}
+.nav-active .nav-icon { color:#fc72ff !important; }
+.nav-item:not(.nav-active):hover { background:#22202e; color:#e5e2e1 !important; }
+.nav-item:not(.nav-active):hover .nav-icon { color:#e5e2e1 !important; }
+</style>
 </head>
-<body class="bg-surface-lowest text-on-surface">
+<body class="flex flex-col" style="height:100vh;overflow:hidden">
 <div class="scanlines"></div>
-<!-- SideNavBar -->
-<aside class="fixed left-0 top-0 h-full flex flex-col justify-between bg-zinc-950 border-r border-zinc-800/40 w-64 z-40">
-<div>
-<div class="p-6">
-<div class="text-2xl font-black tracking-tighter text-[#00fd87] font-space-grotesk">POLYSCAN</div>
-<div class="text-[10px] text-zinc-500 font-mono tracking-widest mt-1">v4.0.2-ALPHA</div>
-</div>
-<nav class="mt-4">
-<!-- Active Nav Item -->
-<a class="flex items-center gap-3 px-4 py-3 bg-zinc-800 text-[#00fd87] border-r-2 border-[#00fd87] font-mono group active-glow" href="#">
-<span class="material-symbols-outlined text-xl" data-icon="terminal">terminal</span>
-<span class="text-sm font-bold tracking-tight">TERMINAL</span>
-</a>
-<a class="flex items-center gap-3 px-4 py-3 text-zinc-500 hover:text-zinc-200 font-mono transition-colors duration-100 group" href="#">
-<span class="material-symbols-outlined text-xl" data-icon="troubleshoot">troubleshoot</span>
-<span class="text-sm font-bold tracking-tight">SCANNERS</span>
-</a>
-<a class="flex items-center gap-3 px-4 py-3 text-zinc-500 hover:text-zinc-200 font-mono transition-colors duration-100 group" href="#">
-<span class="material-symbols-outlined text-xl" data-icon="history">history</span>
-<span class="text-sm font-bold tracking-tight">HISTORY</span>
-</a>
-<a class="flex items-center gap-3 px-4 py-3 text-zinc-500 hover:text-zinc-200 font-mono transition-colors duration-100 group" href="#">
-<span class="material-symbols-outlined text-xl" data-icon="settings">settings</span>
-<span class="text-sm font-bold tracking-tight">SETTINGS</span>
-</a>
-</nav>
-</div>
-<div class="p-4 border-t border-zinc-900">
-<div class="flex items-center justify-between mb-4">
-<div class="flex items-center gap-2">
-<div class="w-2 h-2 rounded-full bg-[#00fd87] animate-pulse"></div>
-<span class="text-[10px] font-mono text-zinc-400">LIVE FEED</span>
-</div>
-<span class="text-[10px] font-mono text-[#00fd87]">14MS LATENCY</span>
-</div>
-<button class="w-full py-3 bg-zinc-900 border border-zinc-800 text-zinc-400 text-xs font-mono flex items-center justify-center gap-2 hover:bg-zinc-800 transition-all">
-<span class="material-symbols-outlined text-sm" data-icon="sensors">sensors</span>
-                VIEW TELEMETRY
-            </button>
-</div>
-</aside>
-<!-- Main Content Area -->
-<main class="ml-64 min-h-screen bg-surface flex flex-col">
-<!-- TopAppBar -->
-<header class="flex items-center justify-between px-6 h-16 bg-zinc-950/80 backdrop-blur-md border-b border-zinc-800/40 sticky top-0 z-30">
-<div class="flex items-center gap-8">
-<div class="text-xs font-bold font-mono text-zinc-500 tracking-widest uppercase">TERMINAL_CORE</div>
-<nav class="hidden md:flex items-center gap-6">
-<a class="text-xs font-bold font-mono text-[#00fd87] border-b border-[#00fd87] py-5" href="#">GLOBAL_MARKETS</a>
-<a class="text-xs font-bold font-mono text-zinc-400 hover:text-[#00fd87] transition-all py-5" href="#">LIQUIDITY_MAP</a>
-</nav>
-</div>
-<div class="flex items-center gap-4">
-<div class="relative group">
-<input class="bg-surface-container-lowest border-b border-outline-variant focus:border-primary-container text-xs font-mono py-1 px-3 w-48 outline-none transition-all placeholder:text-zinc-600" placeholder="SEARCH_MARKETS..." type="text"/>
-</div>
-<div class="flex items-center gap-2 text-zinc-400">
-<button class="p-2 hover:text-[#00fd87] transition-colors">
-<span class="material-symbols-outlined" data-icon="notifications_active">notifications_active</span>
-</button>
-<button class="p-2 hover:text-[#00fd87] transition-colors">
-<span class="material-symbols-outlined" data-icon="account_circle">account_circle</span>
-</button>
-</div>
-<button class="bg-[#00fd87] text-black text-xs font-mono font-bold px-4 py-2 hover:bg-[#00e479] transition-all">
-                    SCAN NOW
-                </button>
-</div>
+
+<!-- HEADER / TOP BAR -->
+<header class="flex items-center justify-between flex-shrink-0" style="height:56px;padding:0 24px;background:#0e0d14;border-bottom:1px solid #2c2b3b;z-index:50">
+  <!-- Left: brand -->
+  <div style="width:240px">
+    <div style="font-size:20px;font-weight:900;color:#fc72ff;letter-spacing:2px;text-transform:uppercase;line-height:1.2">POLYSCAN</div>
+    <div style="font-size:9px;color:#5e5e6e;letter-spacing:0.5px;margin-top:2px">v1.0-ALPHA</div>
+  </div>
+  <!-- Center: tabs -->
+  <div class="flex items-center gap-4" style="font-size:12px;letter-spacing:1.5px">
+    <span style="color:#e5e2e1;font-weight:500;border-bottom:2px solid #fc72ff;padding-bottom:4px">TERMINAL_CORE</span>
+    <span style="color:#3d3b50">|</span>
+    <span style="color:#5e5e6e;font-weight:400">Live Arbitrage Feed</span>
+  </div>
+  <!-- Right: controls -->
+  <div class="flex items-center gap-4">
+    <div class="flex items-center gap-2">
+      <div style="width:8px;height:8px;border-radius:50%;background:#00fd87;animation:pulse 2s infinite"></div>
+      <span style="font-size:12px;color:#5e5e6e">06:45 UTC</span>
+    </div>
+    <button id="scan-btn" onclick="doScan()"
+      class="flex items-center gap-2"
+      style="background:#33ff99;color:#000000;font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:700;letter-spacing:1.5px;padding:10px 20px;border:none;cursor:pointer;text-transform:uppercase;transition:background 0.15s,color 0.15s"
+      onmouseenter="this.style.background='#00ccc9'"
+      onmouseleave="this.style.background='#33ff99'">
+      <span class="material-symbols-outlined" style="font-size:16px">radar</span>
+      SCAN NOW
+    </button>
+  </div>
 </header>
-<!-- Dashboard Content -->
-<div class="p-6 space-y-6">
-<!-- TOP ROW: Stat Cards -->
-<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-<div class="bg-surface-container-low border border-zinc-800/60 p-5 flex flex-col justify-between">
-<div class="text-[10px] font-mono text-zinc-500 tracking-tighter uppercase">Markets Scanned</div>
-<div class="text-4xl font-mono font-bold text-on-surface mt-2">1,243</div>
-<div class="mt-2 flex items-center gap-2">
-<span class="text-[10px] font-mono text-[#00fd87]">+14.2%</span>
-<div class="h-[1px] flex-grow bg-zinc-800"></div>
+
+<!-- TICKER -->
+<div class="flex items-center flex-shrink-0 overflow-hidden" style="height:28px;background:#22202e;border-bottom:1px solid #2c2b3b">
+  <div class="flex items-center flex-shrink-0" style="padding:0 16px;height:100%;background:#0e0d14;border-right:1px solid #2c2b3b">
+    <span style="font-size:8px;color:#fc72ff;letter-spacing:1px">⚡ SIGNALS</span>
+  </div>
+  <div class="flex-1 overflow-hidden">
+    <div class="ticker-inner" style="font-size:11px;font-weight:500;letter-spacing:0.5px">
+      <span style="color:#ff5f52">FED HIKE ↓ −7.0%</span>
+      <span style="color:#00fd87">DOGE $1 ↑ +8.0%</span>
+      <span style="color:#00fd87">ETH ETF ↑ +5.0%</span>
+      <span style="color:#ff5f52">SOL BREAK ↓ −4.0%</span>
+      <span style="color:#ff5f52">BTC 100K ↓ −3.0%</span>
+      <span style="color:#5e5e6e">XRP SEC ↑ +3.5%</span>
+      <span style="color:#ff5f52">STABLE ↓ −4.5%</span>
+      <!-- duplicate for seamless loop -->
+      <span style="color:#ff5f52">FED HIKE ↓ −7.0%</span>
+      <span style="color:#00fd87">DOGE $1 ↑ +8.0%</span>
+      <span style="color:#00fd87">ETH ETF ↑ +5.0%</span>
+      <span style="color:#ff5f52">SOL BREAK ↓ −4.0%</span>
+      <span style="color:#ff5f52">BTC 100K ↓ −3.0%</span>
+      <span style="color:#5e5e6e">XRP SEC ↑ +3.5%</span>
+      <span style="color:#ff5f52">STABLE ↓ −4.5%</span>
+    </div>
+  </div>
 </div>
+
+<!-- BODY: SIDEBAR + MAIN -->
+<div class="flex flex-1 overflow-hidden">
+
+  <!-- SIDEBAR -->
+  <aside class="flex flex-col flex-shrink-0 overflow-y-auto" style="width:240px;background:#0e0d14;border-right:1px solid #2c2b3b">
+
+    <!-- Navigation -->
+    <nav class="mt-4">
+      <a href="#" class="nav-item nav-active flex items-center gap-3" style="padding:12px 20px;font-size:13px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;text-decoration:none;cursor:pointer;transition:all 0.15s">
+        <span class="material-symbols-outlined nav-icon" style="font-size:18px;color:#fc72ff">terminal</span>
+        <span>TERMINAL</span>
+      </a>
+      <a href="#" class="nav-item flex items-center gap-3" style="padding:12px 20px;font-size:13px;font-weight:500;letter-spacing:1.5px;text-transform:uppercase;text-decoration:none;color:#5e5e6e;cursor:pointer;transition:all 0.15s">
+        <span class="material-symbols-outlined nav-icon" style="font-size:18px;color:#5e5e6e">history</span>
+        <span>HISTORY</span>
+      </a>
+      <a href="#" class="nav-item flex items-center gap-3" style="padding:12px 20px;font-size:13px;font-weight:500;letter-spacing:1.5px;text-transform:uppercase;text-decoration:none;color:#5e5e6e;cursor:pointer;transition:all 0.15s">
+        <span class="material-symbols-outlined nav-icon" style="font-size:18px;color:#5e5e6e">settings</span>
+        <span>SETTINGS</span>
+      </a>
+    </nav>
+
+    <!-- spacer -->
+    <div class="flex-1"></div>
+
+    <!-- Session Stats -->
+    <div style="padding:20px;border-top:1px solid #2c2b3b">
+      <div style="font-size:8px;font-weight:500;letter-spacing:1.5px;text-transform:uppercase;color:#5e5e6e;margin-bottom:12px">Session Stats</div>
+      <div class="grid grid-cols-2 gap-2 mb-3">
+        <div style="background:#22202e;border:1px solid #2c2b3b;border-radius:6px;padding:10px 12px">
+          <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:4px">Scanned</div>
+          <div style="font-size:22px;font-weight:700;color:#e5e2e1;line-height:1">1,243</div>
+        </div>
+        <div style="background:#22202e;border:1px solid #2c2b3b;border-radius:6px;padding:10px 12px">
+          <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:4px">Signals</div>
+          <div id="sidebar-count" style="font-size:22px;font-weight:700;color:#00fd87;line-height:1">5</div>
+        </div>
+      </div>
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <div style="width:6px;height:6px;border-radius:50%;background:#00fd87;animation:pulse 2s infinite"></div>
+          <span style="font-size:10px;font-weight:500;letter-spacing:1px;color:#5e5e6e">LIVE FEED</span>
+        </div>
+        <span style="font-size:10px;font-weight:500;color:#00fd87">14ms</span>
+      </div>
+    </div>
+
+    <!-- Filters -->
+    <div style="padding:20px;border-top:1px solid #2c2b3b">
+      <div style="font-size:8px;font-weight:500;letter-spacing:1.5px;text-transform:uppercase;color:#5e5e6e;margin-bottom:12px">Filters</div>
+      <!-- Slider -->
+      <div class="flex justify-between items-center mb-2">
+        <span style="font-size:10px;color:#9b9ba0">Min Gap</span>
+        <span id="gap-label" style="font-size:10px;font-weight:600;color:#e5e2e1">3%</span>
+      </div>
+      <input type="range" min="1" max="20" value="3" id="gap-slider"
+        style="width:100%;height:2px;accent-color:#fc72ff;cursor:pointer;margin-bottom:12px"
+        oninput="document.getElementById('gap-label').textContent=this.value+'%';applyFilter()"/>
+      <!-- Direction toggle -->
+      <div id="dir-btns" class="flex" style="border:1px solid #2c2b3b;border-radius:6px;overflow:hidden;margin-bottom:8px">
+        <button onclick="setDir('ALL',this)" class="dir flex-1 py-1.5" style="background:#e566ff;color:#000000;font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:700;letter-spacing:1px;text-transform:uppercase;border:none;cursor:pointer;transition:all 0.15s" data-dir="ALL">ALL</button>
+        <button onclick="setDir('OVER',this)" class="dir flex-1 py-1.5" style="background:transparent;color:#1a1a2e;font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;border:none;cursor:pointer;transition:all 0.15s"
+          onmouseenter="this.style.color='#c0c0c0'" onmouseleave="if(!this.classList.contains('active-dir'))this.style.color='#1a1a2e'" data-dir="OVER">OVER</button>
+        <button onclick="setDir('UNDER',this)" class="dir flex-1 py-1.5" style="background:transparent;color:#1a1a2e;font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;border:none;cursor:pointer;transition:all 0.15s"
+          onmouseenter="this.style.color='#c0c0c0'" onmouseleave="if(!this.classList.contains('active-dir'))this.style.color='#1a1a2e'" data-dir="UNDER">UNDER</button>
+      </div>
+      <div id="result-label" style="font-size:8px;color:#5e5e6e;letter-spacing:0.5px">5 signals</div>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT -->
+  <main class="flex-1 flex flex-col overflow-hidden">
+    <!-- Card grid (scrollable) -->
+    <div id="card-grid" class="flex-1 overflow-y-auto" style="padding:24px;display:grid;grid-template-columns:1fr 1fr;gap:16px;align-content:start">
+
+      <!-- Card 1: UNDER high -->
+      <div class="signal-card" data-dir="UNDER" data-gap="7" style="background:#22202e;border:1px solid #3d3b50;cursor:pointer;transition:border-color 0.15s"
+        onmouseenter="this.style.borderColor='#00fd8766'" onmouseleave="this.style.borderColor='#3d3b50'"
+        onclick="window.open('https://polymarket.com','_blank')">
+        <div class="flex gap-4" style="padding:16px 16px 0">
+          <!-- Sparkline -->
+          <div class="flex items-end gap-0.5 flex-shrink-0 self-end" style="width:56px;height:52px">
+            <div class="flex-1 rounded-sm" style="height:20%;background:#00fd87;opacity:0.15"></div>
+            <div class="flex-1 rounded-sm" style="height:38%;background:#00fd87;opacity:0.3"></div>
+            <div class="flex-1 rounded-sm" style="height:54%;background:#00fd87;opacity:0.5"></div>
+            <div class="flex-1 rounded-sm" style="height:72%;background:#00fd87;opacity:0.7"></div>
+            <div class="flex-1 rounded-sm" style="height:88%;background:#00fd87;opacity:0.85"></div>
+            <div class="flex-1 rounded-sm" style="height:100%;background:#00fd87"></div>
+          </div>
+          <!-- Content -->
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <span style="background:#0d2218;color:#00fd87;border:1px solid #00fd8444;font-size:9px;font-weight:700;letter-spacing:1px;padding:2px 8px;border-radius:4px">UNDER</span>
+              <span style="font-size:9px;color:#5e5e6e">Scanned 06:45 UTC</span>
+              <span style="font-size:9px;color:#00fd87;margin-left:auto">↑ gap widening</span>
+            </div>
+            <div style="font-family:'Inter',sans-serif;font-size:17px;font-weight:700;color:#e5e2e1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:12px">Fed Rate Hike Sept 2024</div>
+            <div class="grid grid-cols-3 gap-2">
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">YES</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.890</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">NO</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.040</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #00fd8444;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">SUM</div>
+                <div style="font-size:14px;font-weight:600;color:#00fd87">0.930</div>
+              </div>
+            </div>
+          </div>
+          <!-- Gap badge -->
+          <div class="flex-shrink-0 flex flex-col justify-between text-right" style="padding-top:2px">
+            <div>
+              <div style="font-size:44px;font-weight:700;color:#00fd87;line-height:1">7.0<span style="font-size:22px;font-weight:400">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e;margin-top:2px">raw gap</div>
+            </div>
+            <div>
+              <div style="font-size:22px;font-weight:600;color:#00fd87;line-height:1">+5.0<span style="font-size:14px">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e">net (−2% fee)</div>
+            </div>
+          </div>
+        </div>
+        <!-- Gap bar -->
+        <div style="margin:12px 16px 0;height:2px;background:#3d3b50;border-radius:1px">
+          <div class="gap-bar" style="width:70%;height:100%;background:linear-gradient(90deg,#00fd8766,#00fd87);border-radius:1px"></div>
+        </div>
+        <div class="flex justify-between" style="padding:8px 16px 12px;font-size:9px;color:#5e5e6e">
+          <span>gap: 7.0¢ below fair value · buy YES + NO</span>
+          <span style="color:#00fd87;opacity:0">View on Polymarket →</span>
+        </div>
+      </div>
+
+      <!-- Card 2: OVER high -->
+      <div class="signal-card" data-dir="OVER" data-gap="8" style="background:#22202e;border:1px solid #3d3b50;cursor:pointer;transition:border-color 0.15s"
+        onmouseenter="this.style.borderColor='#ff5f5266'" onmouseleave="this.style.borderColor='#3d3b50'"
+        onclick="window.open('https://polymarket.com','_blank')">
+        <div class="flex gap-4" style="padding:16px 16px 0">
+          <div class="flex items-end gap-0.5 flex-shrink-0 self-end" style="width:56px;height:52px">
+            <div class="flex-1 rounded-sm" style="height:22%;background:#ff5f52;opacity:0.15"></div>
+            <div class="flex-1 rounded-sm" style="height:40%;background:#ff5f52;opacity:0.3"></div>
+            <div class="flex-1 rounded-sm" style="height:58%;background:#ff5f52;opacity:0.5"></div>
+            <div class="flex-1 rounded-sm" style="height:76%;background:#ff5f52;opacity:0.7"></div>
+            <div class="flex-1 rounded-sm" style="height:90%;background:#ff5f52;opacity:0.85"></div>
+            <div class="flex-1 rounded-sm" style="height:100%;background:#ff5f52"></div>
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <span style="background:#2a1212;color:#ff5f52;border:1px solid #ff5f5244;font-size:9px;font-weight:700;letter-spacing:1px;padding:2px 8px;border-radius:4px">OVER</span>
+              <span style="font-size:9px;color:#5e5e6e">Scanned 06:44 UTC</span>
+              <span style="font-size:9px;color:#ff5f52;margin-left:auto">⚠ new high</span>
+            </div>
+            <div style="font-family:'Inter',sans-serif;font-size:17px;font-weight:700;color:#e5e2e1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:12px">DOGE hits $1 before halving?</div>
+            <div class="grid grid-cols-3 gap-2">
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">YES</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.550</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">NO</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.530</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #ff5f5244;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">SUM</div>
+                <div style="font-size:14px;font-weight:600;color:#ff5f52">1.080</div>
+              </div>
+            </div>
+          </div>
+          <div class="flex-shrink-0 flex flex-col justify-between text-right" style="padding-top:2px">
+            <div>
+              <div style="font-size:44px;font-weight:700;color:#ff5f52;line-height:1">8.0<span style="font-size:22px;font-weight:400">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e;margin-top:2px">raw gap</div>
+            </div>
+            <div>
+              <div style="font-size:22px;font-weight:600;color:#00fd87;line-height:1">+6.0<span style="font-size:14px">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e">net (−2% fee)</div>
+            </div>
+          </div>
+        </div>
+        <div style="margin:12px 16px 0;height:2px;background:#3d3b50;border-radius:1px">
+          <div class="gap-bar" style="width:80%;height:100%;background:linear-gradient(90deg,#ff5f5266,#ff5f52);border-radius:1px"></div>
+        </div>
+        <div class="flex justify-between" style="padding:8px 16px 12px;font-size:9px;color:#5e5e6e">
+          <span>gap: 8.0¢ above fair value · sell YES + NO</span>
+          <span style="color:#ff5f52;opacity:0">View on Polymarket →</span>
+        </div>
+      </div>
+
+      <!-- Card 3: OVER -->
+      <div class="signal-card" data-dir="OVER" data-gap="5" style="background:#22202e;border:1px solid #3d3b50;cursor:pointer;transition:border-color 0.15s"
+        onmouseenter="this.style.borderColor='#ff5f5266'" onmouseleave="this.style.borderColor='#3d3b50'"
+        onclick="window.open('https://polymarket.com','_blank')">
+        <div class="flex gap-4" style="padding:16px 16px 0">
+          <div class="flex items-end gap-0.5 flex-shrink-0 self-end" style="width:56px;height:52px">
+            <div class="flex-1 rounded-sm" style="height:28%;background:#ff5f52;opacity:0.2"></div>
+            <div class="flex-1 rounded-sm" style="height:45%;background:#ff5f52;opacity:0.38"></div>
+            <div class="flex-1 rounded-sm" style="height:60%;background:#ff5f52;opacity:0.55"></div>
+            <div class="flex-1 rounded-sm" style="height:78%;background:#ff5f52;opacity:0.72"></div>
+            <div class="flex-1 rounded-sm" style="height:90%;background:#ff5f52;opacity:0.86"></div>
+            <div class="flex-1 rounded-sm" style="height:100%;background:#ff5f52"></div>
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <span style="background:#2a1212;color:#ff5f52;border:1px solid #ff5f5244;font-size:9px;font-weight:700;letter-spacing:1px;padding:2px 8px;border-radius:4px">OVER</span>
+              <span style="font-size:9px;color:#5e5e6e">Scanned 06:44 UTC</span>
+            </div>
+            <div style="font-family:'Inter',sans-serif;font-size:17px;font-weight:700;color:#e5e2e1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:12px">ETH ETF Approved by August?</div>
+            <div class="grid grid-cols-3 gap-2">
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">YES</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.681</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">NO</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.344</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #ff5f5244;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">SUM</div>
+                <div style="font-size:14px;font-weight:600;color:#ff5f52">1.025</div>
+              </div>
+            </div>
+          </div>
+          <div class="flex-shrink-0 flex flex-col justify-between text-right" style="padding-top:2px">
+            <div>
+              <div style="font-size:44px;font-weight:700;color:#ff5f52;line-height:1">5.0<span style="font-size:22px;font-weight:400">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e;margin-top:2px">raw gap</div>
+            </div>
+            <div>
+              <div style="font-size:22px;font-weight:600;color:#00fd87;line-height:1">+3.0<span style="font-size:14px">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e">net (−2% fee)</div>
+            </div>
+          </div>
+        </div>
+        <div style="margin:12px 16px 0;height:2px;background:#3d3b50;border-radius:1px">
+          <div class="gap-bar" style="width:50%;height:100%;background:linear-gradient(90deg,#ff5f5266,#ff5f52);border-radius:1px"></div>
+        </div>
+        <div style="padding:8px 16px 12px;font-size:9px;color:#5e5e6e">gap: 5.0¢ above fair value · sell YES + NO</div>
+      </div>
+
+      <!-- Card 4: UNDER -->
+      <div class="signal-card" data-dir="UNDER" data-gap="4" style="background:#22202e;border:1px solid #3d3b50;cursor:pointer;transition:border-color 0.15s"
+        onmouseenter="this.style.borderColor='#00fd8766'" onmouseleave="this.style.borderColor='#3d3b50'"
+        onclick="window.open('https://polymarket.com','_blank')">
+        <div class="flex gap-4" style="padding:16px 16px 0">
+          <div class="flex items-end gap-0.5 flex-shrink-0 self-end" style="width:56px;height:52px">
+            <div class="flex-1 rounded-sm" style="height:18%;background:#00fd87;opacity:0.15"></div>
+            <div class="flex-1 rounded-sm" style="height:36%;background:#00fd87;opacity:0.3"></div>
+            <div class="flex-1 rounded-sm" style="height:54%;background:#00fd87;opacity:0.5"></div>
+            <div class="flex-1 rounded-sm" style="height:72%;background:#00fd87;opacity:0.7"></div>
+            <div class="flex-1 rounded-sm" style="height:88%;background:#00fd87;opacity:0.85"></div>
+            <div class="flex-1 rounded-sm" style="height:100%;background:#00fd87"></div>
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <span style="background:#0d2218;color:#00fd87;border:1px solid #00fd8444;font-size:9px;font-weight:700;letter-spacing:1px;padding:2px 8px;border-radius:4px">UNDER</span>
+              <span style="font-size:9px;color:#5e5e6e">Scanned 06:43 UTC</span>
+            </div>
+            <div style="font-family:'Inter',sans-serif;font-size:17px;font-weight:700;color:#e5e2e1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:12px">Solana Breakpoint Announcement?</div>
+            <div class="grid grid-cols-3 gap-2">
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">YES</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.220</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">NO</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.740</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #00fd8444;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">SUM</div>
+                <div style="font-size:14px;font-weight:600;color:#00fd87">0.960</div>
+              </div>
+            </div>
+          </div>
+          <div class="flex-shrink-0 flex flex-col justify-between text-right" style="padding-top:2px">
+            <div>
+              <div style="font-size:44px;font-weight:700;color:#00fd87;line-height:1">4.0<span style="font-size:22px;font-weight:400">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e;margin-top:2px">raw gap</div>
+            </div>
+            <div>
+              <div style="font-size:22px;font-weight:600;color:#00fd87;line-height:1">+2.0<span style="font-size:14px">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e">net (−2% fee)</div>
+            </div>
+          </div>
+        </div>
+        <div style="margin:12px 16px 0;height:2px;background:#3d3b50;border-radius:1px">
+          <div class="gap-bar" style="width:40%;height:100%;background:linear-gradient(90deg,#00fd8766,#00fd87);border-radius:1px"></div>
+        </div>
+        <div style="padding:8px 16px 12px;font-size:9px;color:#5e5e6e">gap: 4.0¢ below fair value · buy YES + NO</div>
+      </div>
+
+      <!-- Card 5: UNDER low priority -->
+      <div class="signal-card" data-dir="UNDER" data-gap="3" style="background:#22202e;border:1px solid #3d3b50;cursor:pointer;transition:border-color 0.15s;opacity:0.6"
+        onmouseenter="this.style.borderColor='#00fd8766';this.style.opacity='0.85'" onmouseleave="this.style.borderColor='#3d3b50';this.style.opacity='0.6'"
+        onclick="window.open('https://polymarket.com','_blank')">
+        <div class="flex gap-4" style="padding:16px 16px 0">
+          <div class="flex items-end gap-0.5 flex-shrink-0 self-end" style="width:56px;height:52px">
+            <div class="flex-1 rounded-sm" style="height:14%;background:#00fd87;opacity:0.12"></div>
+            <div class="flex-1 rounded-sm" style="height:28%;background:#00fd87;opacity:0.25"></div>
+            <div class="flex-1 rounded-sm" style="height:44%;background:#00fd87;opacity:0.4"></div>
+            <div class="flex-1 rounded-sm" style="height:62%;background:#00fd87;opacity:0.58"></div>
+            <div class="flex-1 rounded-sm" style="height:80%;background:#00fd87;opacity:0.75"></div>
+            <div class="flex-1 rounded-sm" style="height:100%;background:#00fd87"></div>
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <span style="background:#0d2218;color:#00fd87;border:1px solid #00fd8444;font-size:9px;font-weight:700;letter-spacing:1px;padding:2px 8px;border-radius:4px">UNDER</span>
+              <span style="font-size:9px;color:#5e5e6e">Scanned 06:42 UTC</span>
+              <span style="font-size:9px;color:#5e5e6e;margin-left:auto">low priority</span>
+            </div>
+            <div style="font-family:'Inter',sans-serif;font-size:17px;font-weight:700;color:#e5e2e1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:12px">Will BTC hit 100k by EOY?</div>
+            <div class="grid grid-cols-3 gap-2">
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">YES</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.450</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">NO</div>
+                <div style="font-size:14px;font-weight:600;color:#e5e2e1">0.520</div>
+              </div>
+              <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px">
+                <div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">SUM</div>
+                <div style="font-size:14px;font-weight:600;color:#00fd87">0.970</div>
+              </div>
+            </div>
+          </div>
+          <div class="flex-shrink-0 flex flex-col justify-between text-right" style="padding-top:2px">
+            <div>
+              <div style="font-size:44px;font-weight:700;color:#00fd87;line-height:1">3.0<span style="font-size:22px;font-weight:400">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e;margin-top:2px">raw gap</div>
+            </div>
+            <div>
+              <div style="font-size:22px;font-weight:600;color:#5e5e6e;line-height:1">+1.0<span style="font-size:14px">%</span></div>
+              <div style="font-size:9px;color:#5e5e6e">net (−2% fee)</div>
+            </div>
+          </div>
+        </div>
+        <div style="margin:12px 16px 0;height:2px;background:#3d3b50;border-radius:1px">
+          <div class="gap-bar" style="width:30%;height:100%;background:#00fd8766;border-radius:1px"></div>
+        </div>
+        <div style="padding:8px 16px 12px;font-size:9px;color:#5e5e6e">gap: 3.0¢ · at minimum threshold</div>
+      </div>
+
+      <!-- No results -->
+      <div id="no-results" class="hidden col-span-2" style="padding:48px;text-align:center;font-size:11px;color:#5e5e6e">
+        No signals match filter — lower threshold or change direction
+      </div>
+
+    </div>
+
+    <!-- FOOTER BAR -->
+    <footer class="flex items-center justify-between flex-shrink-0" style="height:32px;padding:0 24px;background:#0e0d14;border-top:1px solid #2c2b3b">
+      <div class="flex gap-6" style="font-size:9px;color:#5e5e6e;letter-spacing:0.5px">
+        <span>Polymarket CLOB API</span>
+        <span>fee: 2%/side</span>
+        <span>batch: 500 tokens</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <div style="width:6px;height:6px;border-radius:50%;background:#00fd87;animation:pulse 2s infinite"></div>
+        <span style="font-size:9px;color:#00fd87;letter-spacing:1px">CONNECTED</span>
+      </div>
+    </footer>
+  </main>
 </div>
-<div class="bg-surface-container-low border border-zinc-800/60 p-5 flex flex-col justify-between">
-<div class="text-[10px] font-mono text-zinc-500 tracking-tighter uppercase">Gaps Found</div>
-<div class="text-4xl font-mono font-bold text-[#00fd87] mt-2">07</div>
-<div class="mt-2 flex items-center gap-2 text-zinc-500 text-[10px] font-mono">
-                        POTENTIAL PROFIT: $1,420.44
-                    </div>
-</div>
-<div class="bg-surface-container-low border border-zinc-800/60 p-5 flex flex-col justify-between">
-<div class="text-[10px] font-mono text-zinc-500 tracking-tighter uppercase">Last Scan</div>
-<div class="text-4xl font-mono font-bold text-on-surface mt-2">06:45<span class="text-sm font-normal text-zinc-500 ml-1">UTC</span></div>
-<div class="mt-2 flex items-center gap-2">
-<div class="w-full h-1 bg-zinc-900 overflow-hidden">
-<div class="w-2/3 h-full bg-[#00fd87]"></div>
-</div>
-</div>
-</div>
-</div>
-<!-- SECOND ROW: Filters and Chart -->
-<div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
-<!-- Filter Controls -->
-<div class="lg:col-span-4 bg-surface-container-low p-6 border border-zinc-800/60">
-<h3 class="text-xs font-bold font-mono tracking-widest text-zinc-400 mb-6 uppercase">Control_Parameters</h3>
-<div class="space-y-8">
-<div>
-<div class="flex justify-between mb-3 text-[10px] font-mono">
-<span class="text-zinc-500">MIN GAP THRESHOLD</span>
-<span class="text-[#00fd87]">1.24%</span>
-</div>
-<input class="w-full h-1 bg-zinc-900 appearance-none cursor-pointer accent-[#00fd87]" max="5" min="0" step="0.01" type="range"/>
-</div>
-<div>
-<span class="text-[10px] font-mono text-zinc-500 block mb-3 uppercase">Directional Toggle</span>
-<div class="flex gap-px bg-zinc-900 border border-zinc-900">
-<button class="flex-1 py-2 text-[10px] font-mono font-bold bg-[#00fd87] text-black">ALL</button>
-<button class="flex-1 py-2 text-[10px] font-mono font-bold bg-zinc-950 text-zinc-500 hover:text-zinc-200">OVER</button>
-<button class="flex-1 py-2 text-[10px] font-mono font-bold bg-zinc-950 text-zinc-500 hover:text-zinc-200">UNDER</button>
-</div>
-</div>
-<div class="p-4 bg-zinc-950/50 border border-zinc-800/40">
-<div class="text-[10px] font-mono text-zinc-500 mb-2">AUTO_EXECUTE_STATUS</div>
-<div class="flex items-center gap-2">
-<span class="w-2 h-2 bg-zinc-700"></span>
-<span class="text-[10px] font-mono text-zinc-600 italic">SYSTEM STANDBY - READY</span>
-</div>
-</div>
-</div>
-</div>
-<!-- Bar Chart Distribution -->
-<div class="lg:col-span-8 bg-surface-container-low p-6 border border-zinc-800/60 flex flex-col">
-<div class="flex justify-between items-start mb-6">
-<h3 class="text-xs font-bold font-mono tracking-widest text-zinc-400 uppercase">Real-Time Gap Distribution</h3>
-<div class="flex gap-4 text-[10px] font-mono">
-<div class="flex items-center gap-1"><span class="w-2 h-2 bg-[#00fd87]"></span> UNDER</div>
-<div class="flex items-center gap-1"><span class="w-2 h-2 bg-[#ffb4ab]"></span> OVER</div>
-</div>
-</div>
-<div class="flex-grow flex items-end justify-between gap-1 min-h-[160px]">
-<!-- Chart Bars -->
-<div class="w-full bg-[#ffb4ab]/20 h-1/4"></div>
-<div class="w-full bg-[#00fd87]/40 h-1/2"></div>
-<div class="w-full bg-[#ffb4ab]/40 h-2/3"></div>
-<div class="w-full bg-[#00fd87]/20 h-1/3"></div>
-<div class="w-full bg-[#ffb4ab]/60 h-3/4"></div>
-<div class="w-full bg-[#00fd87]/80 h-full"></div>
-<div class="w-full bg-[#ffb4ab]/30 h-1/2"></div>
-<div class="w-full bg-[#00fd87]/50 h-3/5"></div>
-<div class="w-full bg-[#ffb4ab]/70 h-4/5"></div>
-<div class="w-full bg-[#00fd87]/30 h-1/4"></div>
-<div class="w-full bg-[#ffb4ab]/20 h-1/5"></div>
-<div class="w-full bg-[#00fd87]/90 h-[95%]"></div>
-<div class="w-full bg-[#ffb4ab]/50 h-1/2"></div>
-<div class="w-full bg-[#00fd87]/40 h-3/4"></div>
-<div class="w-full bg-[#ffb4ab]/40 h-2/3"></div>
-<div class="w-full bg-[#00fd87]/60 h-5/6"></div>
-<div class="w-full bg-[#ffb4ab]/30 h-1/2"></div>
-<div class="w-full bg-[#00fd87]/20 h-1/3"></div>
-<div class="w-full bg-[#ffb4ab]/60 h-3/4"></div>
-<div class="w-full bg-[#00fd87]/80 h-full"></div>
-</div>
-<div class="mt-4 border-t border-zinc-800 pt-2 flex justify-between font-mono text-[9px] text-zinc-600">
-<span>-5.0%</span>
-<span>-2.5%</span>
-<span>0.0%</span>
-<span>+2.5%</span>
-<span>+5.0%</span>
-</div>
-</div>
-</div>
-<!-- BOTTOM SECTION: Results Table -->
-<div class="bg-surface-container-low border border-zinc-800/60 overflow-hidden">
-<div class="px-6 py-4 border-b border-zinc-800 flex justify-between items-center bg-zinc-950/30">
-<h3 class="text-xs font-bold font-mono tracking-widest text-zinc-400 uppercase">ACTIVE_ARBITRAGE_SIGNALS</h3>
-<div class="flex gap-2">
-<button class="text-[10px] font-mono p-1 hover:text-[#00fd87]"><span class="material-symbols-outlined text-sm" data-icon="filter_list">filter_list</span></button>
-<button class="text-[10px] font-mono p-1 hover:text-[#00fd87]"><span class="material-symbols-outlined text-sm" data-icon="download">download</span></button>
-</div>
-</div>
-<div class="overflow-x-auto">
-<table class="w-full text-left font-mono text-[11px] leading-none">
-<thead>
-<tr class="bg-zinc-900/50 text-zinc-500 uppercase tracking-widest border-b border-zinc-800">
-<th class="px-6 py-4 font-normal">Market / Question</th>
-<th class="px-6 py-4 font-normal">YES</th>
-<th class="px-6 py-4 font-normal">NO</th>
-<th class="px-6 py-4 font-normal text-right">SUM</th>
-<th class="px-6 py-4 font-normal text-right">GAP</th>
-<th class="px-6 py-4 font-normal text-center">DIRECTION</th>
-<th class="px-6 py-4 font-normal text-right">ACTION</th>
-</tr>
-</thead>
-<tbody>
-<tr class="hover:bg-zinc-800/30 transition-colors border-b border-zinc-900/40">
-<td class="px-6 py-4 text-zinc-200">BTC/USDT Above $75k by May 24?</td>
-<td class="px-6 py-4 text-zinc-400">0.452</td>
-<td class="px-6 py-4 text-zinc-400">0.528</td>
-<td class="px-6 py-4 text-right">0.980</td>
-<td class="px-6 py-4 text-right text-[#00fd87] font-bold">-2.00%</td>
-<td class="px-6 py-4 text-center">
-<span class="inline-block px-2 py-0.5 bg-[#00fd87] text-black text-[9px] font-black uppercase">UNDER</span>
-</td>
-<td class="px-6 py-4 text-right">
-<button class="text-[#00fd87] hover:underline uppercase text-[9px]">Trade</button>
-</td>
-</tr>
-<tr class="bg-zinc-900/20 hover:bg-zinc-800/30 transition-colors border-b border-zinc-900/40">
-<td class="px-6 py-4 text-zinc-200">ETH ETF Approved by August 31st?</td>
-<td class="px-6 py-4 text-zinc-400">0.681</td>
-<td class="px-6 py-4 text-zinc-400">0.344</td>
-<td class="px-6 py-4 text-right">1.025</td>
-<td class="px-6 py-4 text-right text-[#ffb4ab] font-bold">+2.50%</td>
-<td class="px-6 py-4 text-center">
-<span class="inline-block px-2 py-0.5 bg-[#ffb4ab] text-black text-[9px] font-black uppercase">OVER</span>
-</td>
-<td class="px-6 py-4 text-right">
-<button class="text-[#00fd87] hover:underline uppercase text-[9px]">Trade</button>
-</td>
-</tr>
-<tr class="hover:bg-zinc-800/30 transition-colors border-b border-zinc-900/40">
-<td class="px-6 py-4 text-zinc-200">SOL Dominance &gt; 12% by EoW?</td>
-<td class="px-6 py-4 text-zinc-400">0.120</td>
-<td class="px-6 py-4 text-zinc-400">0.865</td>
-<td class="px-6 py-4 text-right">0.985</td>
-<td class="px-6 py-4 text-right text-[#00fd87] font-bold">-1.50%</td>
-<td class="px-6 py-4 text-center">
-<span class="inline-block px-2 py-0.5 bg-[#00fd87] text-black text-[9px] font-black uppercase">UNDER</span>
-</td>
-<td class="px-6 py-4 text-right">
-<button class="text-[#00fd87] hover:underline uppercase text-[9px]">Trade</button>
-</td>
-</tr>
-<tr class="bg-zinc-900/20 hover:bg-zinc-800/30 transition-colors border-b border-zinc-900/40">
-<td class="px-6 py-4 text-zinc-200">L2 TVL Aggregated &gt; $45B?</td>
-<td class="px-6 py-4 text-zinc-400">0.550</td>
-<td class="px-6 py-4 text-zinc-400">0.458</td>
-<td class="px-6 py-4 text-right">1.008</td>
-<td class="px-6 py-4 text-right text-[#ffb4ab] font-bold">+0.80%</td>
-<td class="px-6 py-4 text-center">
-<span class="inline-block px-2 py-0.5 bg-[#ffb4ab] text-black text-[9px] font-black uppercase">OVER</span>
-</td>
-<td class="px-6 py-4 text-right">
-<button class="text-[#00fd87] hover:underline uppercase text-[9px]">Trade</button>
-</td>
-</tr>
-<tr class="hover:bg-zinc-800/30 transition-colors border-b border-zinc-900/40">
-<td class="px-6 py-4 text-zinc-200">Stablecoin Market Cap &gt; $160B?</td>
-<td class="px-6 py-4 text-zinc-400">0.490</td>
-<td class="px-6 py-4 text-zinc-400">0.492</td>
-<td class="px-6 py-4 text-right">0.982</td>
-<td class="px-6 py-4 text-right text-[#00fd87] font-bold">-1.80%</td>
-<td class="px-6 py-4 text-center">
-<span class="inline-block px-2 py-0.5 bg-[#00fd87] text-black text-[9px] font-black uppercase">UNDER</span>
-</td>
-<td class="px-6 py-4 text-right">
-<button class="text-[#00fd87] hover:underline uppercase text-[9px]">Trade</button>
-</td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<!-- Footer / Telemetry -->
-<footer class="mt-auto p-4 border-t border-zinc-800/40 bg-zinc-950 flex justify-between items-center text-[9px] font-mono text-zinc-600 uppercase tracking-[0.2em]">
-<div class="flex gap-6">
-<span>Core_Uptime: 99.992%</span>
-<span>Sub_Clusters: 24/24 Online</span>
-<span>Sync_Delta: 0.000004s</span>
-</div>
-<div class="flex gap-4">
-<span class="text-zinc-400">POLYGON_POS_RPC_MAINNET</span>
-<span class="text-[#00fd87]">ACTIVE_LISTENING</span>
-</div>
-</footer>
-</main>
-</body></html>
+
+<style>
+@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+</style>
+
+<script>
+var activeDir = 'ALL';
+
+function setDir(dir, btn){
+  activeDir = dir;
+  document.querySelectorAll('.dir').forEach(function(b){
+    b.classList.remove('active-dir');
+    b.style.background = 'transparent';
+    b.style.color = '#1a1a2e';
+  });
+  btn.classList.add('active-dir');
+  btn.style.background = '#e566ff';
+  btn.style.color = '#000000';
+  applyFilter();
+}
+
+function applyFilter(){
+  var minGap = parseInt(document.getElementById('gap-slider').value);
+  var cards = document.querySelectorAll('[data-dir][data-gap]');
+  var shown = 0;
+  cards.forEach(function(card){
+    var dir = card.dataset.dir;
+    var gap = parseInt(card.dataset.gap);
+    var ok = (activeDir === 'ALL' || dir === activeDir) && gap >= minGap;
+    card.style.display = ok ? '' : 'none';
+    if(ok) shown++;
+  });
+  document.getElementById('sidebar-count').textContent = shown;
+  document.getElementById('result-label').textContent = shown + ' signals';
+  var noRes = document.getElementById('no-results');
+  if(noRes) noRes.classList.toggle('hidden', shown > 0);
+}
+
+var newSignals = [
+  { dir:'OVER', title:'ADA Vasil Fork Launch?', yes:'0.610', no:'0.440', sum:'1.050', gap:5, net:3, color:'#ff5f52', bg:'#2a1212', border:'#ff5f5244', label:'OVER' },
+  { dir:'UNDER', title:'XRP SEC Settled 2024?', yes:'0.380', no:'0.580', sum:'0.960', gap:4, net:2, color:'#00fd87', bg:'#0d2218', border:'#00fd8444', label:'UNDER' },
+];
+var ni = 0;
+
+function doScan(){
+  var btn = document.getElementById('scan-btn');
+  btn.style.opacity = '0.6';
+  btn.innerHTML = '<span class="material-symbols-outlined" style="font-size:16px">sync</span> SCANNING...';
+  btn.disabled = true;
+  setTimeout(function(){
+    btn.style.opacity = '1';
+    btn.innerHTML = '<span class="material-symbols-outlined" style="font-size:16px">radar</span> SCAN NOW';
+    btn.disabled = false;
+    injectCard();
+  }, 1800);
+}
+
+function injectCard(){
+  var d = newSignals[ni % newSignals.length]; ni++;
+  var card = document.createElement('div');
+  card.className = 'signal-card';
+  card.dataset.dir = d.dir;
+  card.dataset.gap = d.gap;
+  card.style.cssText = 'background:#22202e;border:1px solid #3d3b50;cursor:pointer;transition:border-color 0.15s';
+  card.addEventListener('mouseenter', function(){ this.style.borderColor = d.color+'66'; });
+  card.addEventListener('mouseleave', function(){ this.style.borderColor = '#3d3b50'; });
+  card.addEventListener('click', function(){ window.open('https://polymarket.com','_blank'); });
+  card.innerHTML = `
+    <div class="flex gap-4" style="padding:16px 16px 0">
+      <div class="flex items-end gap-0.5 flex-shrink-0 self-end" style="width:56px;height:52px">
+        <div class="flex-1 rounded-sm" style="height:40%;background:${d.color};opacity:0.3"></div>
+        <div class="flex-1 rounded-sm" style="height:65%;background:${d.color};opacity:0.6"></div>
+        <div class="flex-1 rounded-sm" style="height:100%;background:${d.color}"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 mb-2">
+          <span style="background:${d.bg};color:${d.color};border:1px solid ${d.border};font-size:9px;font-weight:700;letter-spacing:1px;padding:2px 8px;border-radius:4px">${d.label}</span>
+          <span style="font-size:9px;color:#5e5e6e">just now</span>
+          <span style="font-size:9px;color:#fc72ff;margin-left:auto;animation:pulse 1s infinite">⚡ new signal</span>
+        </div>
+        <div style="font-family:'Inter',sans-serif;font-size:17px;font-weight:700;color:#e5e2e1;overflow:hidden;text-overflow:ellipsis;margin-bottom:12px">${d.title}</div>
+        <div class="grid grid-cols-3 gap-2">
+          <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px"><div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">YES</div><div style="font-size:14px;font-weight:600;color:#e5e2e1">${d.yes}</div></div>
+          <div style="background:#1c1b1b;border:1px solid #2c2b3b;border-radius:4px;padding:8px 10px"><div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">NO</div><div style="font-size:14px;font-weight:600;color:#e5e2e1">${d.no}</div></div>
+          <div style="background:#1c1b1b;border:1px solid ${d.border};border-radius:4px;padding:8px 10px"><div style="font-size:8px;letter-spacing:1px;text-transform:uppercase;color:#5e5e6e;margin-bottom:3px">SUM</div><div style="font-size:14px;font-weight:600;color:${d.color}">${d.sum}</div></div>
+        </div>
+      </div>
+      <div class="flex-shrink-0 flex flex-col justify-between text-right" style="padding-top:2px">
+        <div>
+          <div style="font-size:44px;font-weight:700;line-height:1;color:${d.color}">${d.gap}.0<span style="font-size:22px;font-weight:400">%</span></div>
+          <div style="font-size:9px;color:#5e5e6e;margin-top:2px">raw gap</div>
+        </div>
+        <div>
+          <div style="font-size:22px;font-weight:600;color:#00fd87;line-height:1">+${d.net}.0<span style="font-size:14px">%</span></div>
+          <div style="font-size:9px;color:#5e5e6e">net (−2% fee)</div>
+        </div>
+      </div>
+    </div>
+    <div style="margin:12px 16px 0;height:2px;background:#3d3b50;border-radius:1px">
+      <div style="width:${d.gap*10}%;height:100%;background:${d.color};border-radius:1px"></div>
+    </div>
+    <div style="padding:8px 16px 12px;font-size:9px;color:#5e5e6e">gap: ${d.gap}.0¢</div>
+  `;
+  var grid = document.getElementById('card-grid');
+  grid.insertBefore(card, grid.firstChild);
+  var cnt = document.getElementById('sidebar-count');
+  cnt.textContent = parseInt(cnt.textContent) + 1;
+  document.getElementById('result-label').textContent = (parseInt(document.getElementById('result-label').textContent) + 1) + ' signals';
+}
+</script>
+</body>
+</html>

--- a/stitch/scanner-main.html
+++ b/stitch/scanner-main.html
@@ -1,289 +1,449 @@
 <!DOCTYPE html>
-
-<html class="dark" lang="en"><head>
+<html class="dark" lang="en">
+<head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>POLYSCAN Terminal</title>
+<title>POLYSCAN — Live Feed (Mobile)</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<script id="tailwind-config">
-      tailwind.config = {
-        darkMode: "class",
-        theme: {
-          extend: {
-            colors: {
-              "on-primary": "#006532",
-              "on-primary-container": "#005b2c",
-              "outline": "#767575",
-              "on-tertiary-fixed-variant": "#005361",
-              "inverse-on-surface": "#565555",
-              "on-error": "#490006",
-              "on-tertiary-container": "#004956",
-              "error-dim": "#d7383b",
-              "on-primary-fixed": "#004621",
-              "on-secondary-fixed": "#70000b",
-              "secondary-dim": "#df2b31",
-              "primary": "#a4ffb9",
-              "on-tertiary": "#005361",
-              "on-surface": "#ffffff",
-              "on-secondary-fixed-variant": "#a60016",
-              "tertiary-dim": "#00cdee",
-              "surface-dim": "#0e0e0e",
-              "tertiary": "#7ee6ff",
-              "inverse-surface": "#fcf9f8",
-              "surface-container": "#1a1919",
-              "surface-container-lowest": "#000000",
-              "background": "#0e0e0e",
-              "on-background": "#ffffff",
-              "primary-dim": "#00ed7e",
-              "surface": "#0e0e0e",
-              "surface-container-highest": "#262626",
-              "surface-variant": "#262626",
-              "secondary": "#ff7169",
-              "surface-container-low": "#131313",
-              "primary-fixed-dim": "#00ed7e",
-              "on-surface-variant": "#adaaaa",
-              "secondary-fixed-dim": "#ffafa9",
-              "primary-container": "#00fd87",
-              "primary-fixed": "#00fd87",
-              "on-secondary-container": "#fff6f4",
-              "error": "#ff716c",
-              "error-container": "#9f0519",
-              "on-tertiary-fixed": "#00333d",
-              "tertiary-fixed-dim": "#00cdee",
-              "on-error-container": "#ffa8a3",
-              "inverse-primary": "#006e37",
-              "surface-container-high": "#201f1f",
-              "surface-tint": "#a4ffb9",
-              "on-primary-fixed-variant": "#006632",
-              "surface-bright": "#2c2c2c",
-              "secondary-fixed": "#ffc3be",
-              "tertiary-container": "#00dcff",
-              "tertiary-fixed": "#00dcff",
-              "outline-variant": "#484847",
-              "secondary-container": "#be0b1d",
-              "on-secondary": "#490005"
-            },
-            fontFamily: {
-              "headline": ["Space Grotesk"],
-              "body": ["Inter"],
-              "label": ["Space Grotesk"]
-            },
-            borderRadius: {"DEFAULT": "0px", "lg": "0px", "xl": "0px", "full": "9999px"},
-          },
-        },
-      }
-    </script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<script>
+tailwind.config = {
+  darkMode:"class",
+  theme:{ extend:{ colors:{
+    /* Uniswap dark palette */
+    "uni-bg":       "#13111A",
+    "uni-surface":  "#1B1A23",
+    "uni-surface2": "#22202E",
+    "uni-surface3": "#2C2A3A",
+    "uni-border":   "#2C2B3B",
+    "uni-border2":  "#3D3B50",
+    "uni-text":     "#F5F4F5",
+    "uni-text2":    "#9B9BA0",
+    "uni-text3":    "#5E5E6E",
+    "uni-pink":     "#FC72FF",   /* Uniswap signature pink */
+    "uni-pink-dim": "#E040FB",
+    "uni-green":    "#40B66B",   /* success/UNDER */
+    "uni-red":      "#FF5F52",   /* error/OVER */
+    "uni-green-bg": "#0D2218",
+    "uni-red-bg":   "#2A1212",
+  }, fontFamily:{
+    sans:['Inter','sans-serif'],
+    mono:['"JetBrains Mono"','monospace'],
+  },
+  borderRadius:{
+    DEFAULT:"12px", sm:"8px", lg:"16px", xl:"20px", "2xl":"24px", full:"9999px"
+  } } }
+}
+</script>
 <style>
-        .material-symbols-outlined {
-            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-            display: inline-block;
-            line-height: 1;
-        }
-        body {
-            background-color: #0e0e0e;
-            color: #ffffff;
-            font-family: 'Inter', sans-serif;
-            -webkit-font-smoothing: antialiased;
-        }
-        .mono {
-            font-family: 'Space Grotesk', monospace;
-        }
-        /* Custom scrollbar for high-density tables */
-        ::-webkit-scrollbar {
-            width: 4px;
-            height: 4px;
-        }
-        ::-webkit-scrollbar-track {
-            background: #0e0e0e;
-        }
-        ::-webkit-scrollbar-thumb {
-            background: #201f1f;
-        }
-    </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
-  </head>
-<body class="flex flex-col min-h-screen pb-20">
-<!-- TopAppBar -->
-<header class="flex justify-between items-center px-4 py-3 w-full bg-[#0e0e0e] border-b border-[#201f1f] sticky top-0 z-50">
-<div class="flex items-center gap-2">
-<span class="material-symbols-outlined text-[#00ff88]" data-icon="terminal">terminal</span>
-<h1 class="text-xl font-bold tracking-tighter text-[#00ff88] font-mono uppercase tracking-widest text-sm">POLYSCAN</h1>
-</div>
-<button class="bg-[#00fd87] text-[#005b2c] font-['Space_Grotesk'] uppercase tracking-widest text-[10px] font-bold px-3 py-1.5 hover:opacity-80 transition-opacity flex items-center gap-1">
-            Scan Now
-        </button>
+* { box-sizing:border-box; }
+body { background:#13111A; color:#F5F4F5; font-family:'Inter',sans-serif; -webkit-font-smoothing:antialiased; margin:0; }
+.material-symbols-outlined { font-variation-settings:'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24; display:inline-block; line-height:1; }
+::-webkit-scrollbar { width:4px; height:4px; }
+::-webkit-scrollbar-track { background:#13111A; }
+::-webkit-scrollbar-thumb { background:#2C2B3B; border-radius:9999px; }
+/* Uniswap pink glow effect */
+.pink-glow { box-shadow: 0 0 20px rgba(252,114,255,0.15); }
+/* gradient badge */
+.uni-badge { background: linear-gradient(135deg, #FC72FF22, #FC72FF11); border: 1px solid #FC72FF44; }
+@keyframes slideDown { from { opacity:0; transform:translateY(-10px); } to { opacity:1; transform:translateY(0); } }
+.signal-card { animation: slideDown 0.25s ease-out; }
+@keyframes ticker { 0% { transform:translateX(100%); } 100% { transform:translateX(-100%); } }
+.ticker-text { animation: ticker 28s linear infinite; }
+.gap-bar { transition: width 0.6s ease; }
+</style>
+</head>
+<body class="min-h-screen pb-20" style="background:#13111A">
+
+<!-- HEADER -->
+<header class="sticky top-0 z-50 border-b" style="background:#13111Aee;backdrop-filter:blur(12px);border-color:#2C2B3B">
+  <div class="flex items-center justify-between px-4 py-3">
+    <div class="flex items-center gap-2">
+      <!-- Uniswap-style unicorn pink logo -->
+      <div class="w-7 h-7 rounded-full flex items-center justify-center" style="background:linear-gradient(135deg,#FC72FF,#9B51E0)">
+        <span class="material-symbols-outlined text-white text-sm">auto_awesome</span>
+      </div>
+      <span class="font-sans font-bold text-[#F5F4F5] text-base tracking-tight">Polyscan</span>
+      <span class="font-mono text-[9px] px-1.5 py-0.5 rounded-full" style="background:#FC72FF22;color:#FC72FF;border:1px solid #FC72FF44">alpha</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <div class="flex items-center gap-1.5 px-2 py-1 rounded-full" style="background:#1B1A23;border:1px solid #2C2B3B">
+        <div class="w-1.5 h-1.5 rounded-full animate-pulse" style="background:#40B66B"></div>
+        <span class="font-mono text-[9px]" style="color:#40B66B">Live</span>
+      </div>
+      <button id="scan-btn" onclick="triggerScan()"
+        class="font-sans font-semibold text-[13px] px-4 py-2 rounded-xl flex items-center gap-1.5 transition-all"
+        style="background:linear-gradient(135deg,#FC72FF,#9B51E0);color:white">
+        <span class="material-symbols-outlined text-sm">radar</span>
+        Scan
+      </button>
+    </div>
+  </div>
 </header>
-<main class="flex-grow p-4 space-y-4">
-<!-- Stats Row -->
-<div class="grid grid-cols-3 gap-1">
-<div class="bg-surface-container-low p-3 border-l-2 border-primary">
-<p class="text-[10px] uppercase font-label text-on-surface-variant leading-none mb-1">Markets Scanned</p>
-<p class="text-xl font-bold mono text-on-surface">1243</p>
+
+<!-- TICKER TAPE -->
+<div class="overflow-hidden h-7 flex items-center" style="background:#1B1A23;border-bottom:1px solid #2C2B3B">
+  <div class="font-mono text-[8px] px-2 h-full flex items-center shrink-0 whitespace-nowrap" style="background:#22202E;border-right:1px solid #2C2B3B;color:#FC72FF">⚡</div>
+  <div class="flex-1 overflow-hidden">
+    <div class="ticker-text whitespace-nowrap font-mono text-[9px] flex items-center gap-8 inline-flex">
+      <span style="color:#40B66B">FED HIKE ↓ −7.0%</span>
+      <span style="color:#FF5F52">DOGE $1 ↑ +8.0%</span>
+      <span style="color:#FF5F52">ETH ETF ↑ +5.0%</span>
+      <span style="color:#40B66B">SOL BREAK ↓ −4.0%</span>
+      <span style="color:#40B66B">BTC 100K ↓ −3.0%</span>
+      <span style="color:#9B9BA0">XRP SEC ↑ +3.5%</span>
+      <span style="color:#40B66B">STABLE ↓ −4.5%</span>
+    </div>
+  </div>
 </div>
-<div class="bg-surface-container-low p-3 border-l-2 border-primary">
-<p class="text-[10px] uppercase font-label text-on-surface-variant leading-none mb-1">Gaps Found</p>
-<p class="text-xl font-bold mono text-primary">7</p>
+
+<!-- STATS ROW -->
+<div class="grid grid-cols-3 gap-3 px-3 py-3" style="background:#13111A">
+  <div class="rounded-2xl p-3" style="background:#1B1A23;border:1px solid #2C2B3B">
+    <div class="text-[10px] font-sans mb-1" style="color:#9B9BA0">Scanned</div>
+    <div class="font-mono text-lg font-bold" style="color:#F5F4F5">1,243</div>
+  </div>
+  <div class="rounded-2xl p-3" style="background:#1B1A23;border:1px solid #2C2B3B">
+    <div class="text-[10px] font-sans mb-1" style="color:#9B9BA0">Signals</div>
+    <div class="font-mono text-lg font-bold" style="color:#FC72FF" id="signal-count">5</div>
+  </div>
+  <div class="rounded-2xl p-3" style="background:#1B1A23;border:1px solid #2C2B3B">
+    <div class="text-[10px] font-sans mb-1" style="color:#9B9BA0">Last Scan</div>
+    <div class="font-mono text-lg font-bold" style="color:#F5F4F5">06:45<span class="text-[10px] font-normal ml-1" style="color:#9B9BA0">UTC</span></div>
+  </div>
 </div>
-<div class="bg-surface-container-low p-3 border-l-2 border-outline-variant">
-<p class="text-[10px] uppercase font-label text-on-surface-variant leading-none mb-1">Last Scan</p>
-<p class="text-xl font-bold mono text-on-surface">06:45<span class="text-xs ml-1 text-on-surface-variant">UTC</span></p>
+
+<!-- FILTER BAR -->
+<div class="sticky z-40 flex items-center gap-2 px-3 py-2.5 flex-wrap gap-y-2" style="top:57px;background:#13111Aee;backdrop-filter:blur(12px);border-bottom:1px solid #2C2B3B">
+  <!-- Direction toggle -->
+  <div class="flex rounded-xl overflow-hidden p-0.5" style="background:#1B1A23;border:1px solid #2C2B3B">
+    <button onclick="setDir('ALL',this)" class="dir active text-[10px] font-sans font-semibold px-3 py-1.5 rounded-lg transition-all" style="background:linear-gradient(135deg,#FC72FF,#9B51E0);color:white" data-dir="ALL">All</button>
+    <button onclick="setDir('OVER',this)" class="dir text-[10px] font-sans font-medium px-3 py-1.5 rounded-lg transition-all" style="color:#9B9BA0" data-dir="OVER">Over</button>
+    <button onclick="setDir('UNDER',this)" class="dir text-[10px] font-sans font-medium px-3 py-1.5 rounded-lg transition-all" style="color:#9B9BA0" data-dir="UNDER">Under</button>
+  </div>
+  <!-- Gap slider -->
+  <div class="flex items-center gap-2 flex-1 min-w-0">
+    <span class="text-[10px] font-sans whitespace-nowrap" style="color:#9B9BA0">Min</span>
+    <input type="range" min="1" max="20" value="3" id="gap-slider"
+      class="flex-1 h-1 appearance-none cursor-pointer rounded-full"
+      style="accent-color:#FC72FF"
+      oninput="document.getElementById('gap-label').textContent=this.value+'%';applyFilter()"/>
+    <span class="font-mono text-[10px] font-semibold w-7 text-right" style="color:#FC72FF" id="gap-label">3%</span>
+  </div>
+  <span class="text-[10px] font-sans ml-auto" style="color:#9B9BA0" id="count-label">5 signals</span>
 </div>
+
+<!-- SIGNAL CARDS -->
+<div class="px-3 pt-3 pb-2 space-y-2.5" id="feed">
+
+  <!-- Card 1: UNDER high -->
+  <div class="signal-card rounded-2xl cursor-pointer group transition-all duration-150 hover:scale-[1.01]"
+    style="background:#1B1A23;border:1px solid #2C2B3B"
+    data-dir="UNDER" data-gap="7"
+    onmouseenter="this.style.borderColor='#40B66B55';this.style.boxShadow='0 0 16px #40B66B22'"
+    onmouseleave="this.style.borderColor='#2C2B3B';this.style.boxShadow='none'"
+    onclick="window.open('https://polymarket.com','_blank')">
+    <div class="flex items-start gap-3 p-3.5">
+      <!-- Sparkline -->
+      <div class="flex items-end gap-px h-9 w-10 shrink-0 self-end">
+        <div class="flex-1 rounded-t-sm opacity-20" style="height:30%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-40" style="height:50%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-65" style="height:65%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-85" style="height:80%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm" style="height:100%;background:#40B66B"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-1.5 mb-1.5">
+          <span class="px-2 py-0.5 rounded-full text-[9px] font-sans font-semibold" style="background:#0D2218;color:#40B66B;border:1px solid #40B66B44">UNDER</span>
+          <span class="text-[9px] font-mono" style="color:#5E5E6E">06:45</span>
+          <span class="text-[9px] font-mono ml-auto" style="color:#40B66B">↑ trend</span>
+        </div>
+        <div class="font-sans font-semibold text-[13px] truncate mb-1.5" style="color:#F5F4F5">Fed Rate Hike Sept 2024</div>
+        <div class="flex items-center gap-3 font-mono text-[9px]" style="color:#9B9BA0">
+          <span>Y <span style="color:#F5F4F5">0.890</span></span>
+          <span>N <span style="color:#F5F4F5">0.040</span></span>
+          <span>Σ <span style="color:#40B66B" class="font-bold">0.930</span></span>
+        </div>
+      </div>
+      <div class="shrink-0 text-right self-start">
+        <div class="font-mono text-xl font-bold leading-none" style="color:#40B66B">7.0<span class="text-xs">%</span></div>
+        <div class="font-mono text-[9px] mt-0.5" style="color:#9B9BA0">net +5.0%</div>
+      </div>
+    </div>
+    <div class="mx-3.5 h-1 rounded-full mb-3" style="background:#22202E">
+      <div class="h-full rounded-full gap-bar" style="width:70%;background:linear-gradient(90deg,#40B66B88,#40B66B)"></div>
+    </div>
+  </div>
+
+  <!-- Card 2: OVER high -->
+  <div class="signal-card rounded-2xl cursor-pointer group transition-all duration-150 hover:scale-[1.01]"
+    style="background:#1B1A23;border:1px solid #2C2B3B"
+    data-dir="OVER" data-gap="8"
+    onmouseenter="this.style.borderColor='#FF5F5255';this.style.boxShadow='0 0 16px #FF5F5222'"
+    onmouseleave="this.style.borderColor='#2C2B3B';this.style.boxShadow='none'"
+    onclick="window.open('https://polymarket.com','_blank')">
+    <div class="flex items-start gap-3 p-3.5">
+      <div class="flex items-end gap-px h-9 w-10 shrink-0 self-end">
+        <div class="flex-1 rounded-t-sm opacity-20" style="height:35%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm opacity-40" style="height:55%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm opacity-65" style="height:70%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm opacity-85" style="height:85%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm" style="height:100%;background:#FF5F52"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-1.5 mb-1.5">
+          <span class="px-2 py-0.5 rounded-full text-[9px] font-sans font-semibold" style="background:#2A1212;color:#FF5F52;border:1px solid #FF5F5244">OVER</span>
+          <span class="text-[9px] font-mono" style="color:#5E5E6E">06:44</span>
+          <span class="text-[9px] font-mono ml-auto" style="color:#FF5F52">new high ⚠</span>
+        </div>
+        <div class="font-sans font-semibold text-[13px] truncate mb-1.5" style="color:#F5F4F5">DOGE hits $1 before halving?</div>
+        <div class="flex items-center gap-3 font-mono text-[9px]" style="color:#9B9BA0">
+          <span>Y <span style="color:#F5F4F5">0.550</span></span>
+          <span>N <span style="color:#F5F4F5">0.530</span></span>
+          <span>Σ <span style="color:#FF5F52" class="font-bold">1.080</span></span>
+        </div>
+      </div>
+      <div class="shrink-0 text-right self-start">
+        <div class="font-mono text-xl font-bold leading-none" style="color:#FF5F52">8.0<span class="text-xs">%</span></div>
+        <div class="font-mono text-[9px] mt-0.5" style="color:#9B9BA0">net +6.0%</div>
+      </div>
+    </div>
+    <div class="mx-3.5 h-1 rounded-full mb-3" style="background:#22202E">
+      <div class="h-full rounded-full gap-bar" style="width:80%;background:linear-gradient(90deg,#FF5F5288,#FF5F52)"></div>
+    </div>
+  </div>
+
+  <!-- Card 3: OVER -->
+  <div class="signal-card rounded-2xl cursor-pointer transition-all duration-150 hover:scale-[1.01]"
+    style="background:#1B1A23;border:1px solid #2C2B3B"
+    data-dir="OVER" data-gap="5"
+    onmouseenter="this.style.borderColor='#FF5F5255';this.style.boxShadow='0 0 16px #FF5F5222'"
+    onmouseleave="this.style.borderColor='#2C2B3B';this.style.boxShadow='none'"
+    onclick="window.open('https://polymarket.com','_blank')">
+    <div class="flex items-start gap-3 p-3.5">
+      <div class="flex items-end gap-px h-9 w-10 shrink-0 self-end">
+        <div class="flex-1 rounded-t-sm opacity-30" style="height:40%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm opacity-50" style="height:55%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm opacity-70" style="height:70%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm opacity-85" style="height:82%;background:#FF5F52"></div>
+        <div class="flex-1 rounded-t-sm" style="height:100%;background:#FF5F52"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-1.5 mb-1.5">
+          <span class="px-2 py-0.5 rounded-full text-[9px] font-sans font-semibold" style="background:#2A1212;color:#FF5F52;border:1px solid #FF5F5244">OVER</span>
+          <span class="text-[9px] font-mono" style="color:#5E5E6E">06:44</span>
+        </div>
+        <div class="font-sans font-semibold text-[13px] truncate mb-1.5" style="color:#F5F4F5">ETH ETF Approved by August?</div>
+        <div class="flex items-center gap-3 font-mono text-[9px]" style="color:#9B9BA0">
+          <span>Y <span style="color:#F5F4F5">0.681</span></span>
+          <span>N <span style="color:#F5F4F5">0.344</span></span>
+          <span>Σ <span style="color:#FF5F52" class="font-bold">1.025</span></span>
+        </div>
+      </div>
+      <div class="shrink-0 text-right self-start">
+        <div class="font-mono text-xl font-bold leading-none" style="color:#FF5F52">5.0<span class="text-xs">%</span></div>
+        <div class="font-mono text-[9px] mt-0.5" style="color:#9B9BA0">net +3.0%</div>
+      </div>
+    </div>
+    <div class="mx-3.5 h-1 rounded-full mb-3" style="background:#22202E">
+      <div class="h-full rounded-full gap-bar" style="width:50%;background:linear-gradient(90deg,#FF5F5288,#FF5F52)"></div>
+    </div>
+  </div>
+
+  <!-- Card 4: UNDER -->
+  <div class="signal-card rounded-2xl cursor-pointer transition-all duration-150 hover:scale-[1.01]"
+    style="background:#1B1A23;border:1px solid #2C2B3B"
+    data-dir="UNDER" data-gap="4"
+    onmouseenter="this.style.borderColor='#40B66B55';this.style.boxShadow='0 0 16px #40B66B22'"
+    onmouseleave="this.style.borderColor='#2C2B3B';this.style.boxShadow='none'"
+    onclick="window.open('https://polymarket.com','_blank')">
+    <div class="flex items-start gap-3 p-3.5">
+      <div class="flex items-end gap-px h-9 w-10 shrink-0 self-end">
+        <div class="flex-1 rounded-t-sm opacity-25" style="height:30%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-45" style="height:50%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-65" style="height:65%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-85" style="height:80%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm" style="height:100%;background:#40B66B"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-1.5 mb-1.5">
+          <span class="px-2 py-0.5 rounded-full text-[9px] font-sans font-semibold" style="background:#0D2218;color:#40B66B;border:1px solid #40B66B44">UNDER</span>
+          <span class="text-[9px] font-mono" style="color:#5E5E6E">06:43</span>
+        </div>
+        <div class="font-sans font-semibold text-[13px] truncate mb-1.5" style="color:#F5F4F5">Solana Breakpoint Announcement?</div>
+        <div class="flex items-center gap-3 font-mono text-[9px]" style="color:#9B9BA0">
+          <span>Y <span style="color:#F5F4F5">0.220</span></span>
+          <span>N <span style="color:#F5F4F5">0.740</span></span>
+          <span>Σ <span style="color:#40B66B" class="font-bold">0.960</span></span>
+        </div>
+      </div>
+      <div class="shrink-0 text-right self-start">
+        <div class="font-mono text-xl font-bold leading-none" style="color:#40B66B">4.0<span class="text-xs">%</span></div>
+        <div class="font-mono text-[9px] mt-0.5" style="color:#9B9BA0">net +2.0%</div>
+      </div>
+    </div>
+    <div class="mx-3.5 h-1 rounded-full mb-3" style="background:#22202E">
+      <div class="h-full rounded-full gap-bar" style="width:40%;background:linear-gradient(90deg,#40B66B88,#40B66B)"></div>
+    </div>
+  </div>
+
+  <!-- Card 5: UNDER low -->
+  <div class="signal-card rounded-2xl cursor-pointer transition-all duration-150 opacity-60 hover:opacity-80"
+    style="background:#1B1A23;border:1px solid #2C2B3B"
+    data-dir="UNDER" data-gap="3"
+    onclick="window.open('https://polymarket.com','_blank')">
+    <div class="flex items-start gap-3 p-3.5">
+      <div class="flex items-end gap-px h-9 w-10 shrink-0 self-end">
+        <div class="flex-1 rounded-t-sm opacity-20" style="height:25%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-35" style="height:38%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-50" style="height:52%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm opacity-70" style="height:70%;background:#40B66B"></div>
+        <div class="flex-1 rounded-t-sm" style="height:100%;background:#40B66B"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-1.5 mb-1.5">
+          <span class="px-2 py-0.5 rounded-full text-[9px] font-sans font-semibold" style="background:#0D2218;color:#40B66B;border:1px solid #40B66B44">UNDER</span>
+          <span class="text-[9px] font-mono" style="color:#5E5E6E">06:42</span>
+          <span class="text-[9px] font-sans ml-auto" style="color:#5E5E6E">low priority</span>
+        </div>
+        <div class="font-sans font-semibold text-[13px] truncate mb-1.5" style="color:#F5F4F5">Will BTC hit 100k by EOY?</div>
+        <div class="flex items-center gap-3 font-mono text-[9px]" style="color:#9B9BA0">
+          <span>Y <span style="color:#F5F4F5">0.450</span></span>
+          <span>N <span style="color:#F5F4F5">0.520</span></span>
+          <span>Σ <span style="color:#40B66B" class="font-bold">0.970</span></span>
+        </div>
+      </div>
+      <div class="shrink-0 text-right self-start">
+        <div class="font-mono text-xl font-bold leading-none" style="color:#40B66B">3.0<span class="text-xs">%</span></div>
+        <div class="font-mono text-[9px] mt-0.5" style="color:#9B9BA0">net +1.0%</div>
+      </div>
+    </div>
+    <div class="mx-3.5 h-1 rounded-full mb-3" style="background:#22202E">
+      <div class="h-full rounded-full gap-bar" style="width:30%;background:#40B66B88"></div>
+    </div>
+  </div>
+
 </div>
-<!-- Filter Bar -->
-<section class="bg-surface-container p-4 space-y-4">
-<div class="flex flex-col gap-2">
-<div class="flex justify-between items-center">
-<label class="text-[10px] uppercase font-label text-on-surface-variant">Min gap threshold</label>
-<span class="text-xs mono text-primary">3¢ minimum</span>
+
+<!-- No results -->
+<div id="no-results" class="hidden px-4 py-10 text-center font-sans text-[11px]" style="color:#9B9BA0">
+  No signals match filter — try lowering the threshold
 </div>
-<input class="w-full h-1 bg-surface-container-highest appearance-none cursor-pointer accent-primary" max="50" min="1" type="range" value="3"/>
-</div>
-<div class="flex bg-surface-container-lowest p-1">
-<button class="flex-1 py-2 text-[10px] uppercase font-label bg-surface-container-highest text-primary font-bold">ALL</button>
-<button class="flex-1 py-2 text-[10px] uppercase font-label text-on-surface-variant hover:text-on-surface">OVER</button>
-<button class="flex-1 py-2 text-[10px] uppercase font-label text-on-surface-variant hover:text-on-surface">UNDER</button>
-</div>
-</section>
-<!-- Bar Chart Visualizer -->
-<section class="bg-surface-container p-4">
-<div class="flex justify-between items-center mb-4">
-<h3 class="text-[10px] uppercase font-label tracking-widest text-on-surface-variant">Real-time Gap Distribution</h3>
-<span class="material-symbols-outlined text-[16px] text-on-surface-variant" data-icon="monitoring">monitoring</span>
-</div>
-<div class="flex items-end justify-between h-24 gap-1">
-<div class="w-full bg-secondary opacity-80" style="height: 40%" title="OVER"></div>
-<div class="w-full bg-primary opacity-80" style="height: 65%" title="UNDER"></div>
-<div class="w-full bg-primary opacity-80" style="height: 25%" title="UNDER"></div>
-<div class="w-full bg-secondary opacity-80" style="height: 90%" title="OVER"></div>
-<div class="w-full bg-primary opacity-80" style="height: 55%" title="UNDER"></div>
-<div class="w-full bg-primary opacity-80" style="height: 15%" title="UNDER"></div>
-<div class="w-full bg-secondary opacity-80" style="height: 45%" title="OVER"></div>
-<div class="w-full bg-primary opacity-80" style="height: 75%" title="UNDER"></div>
-<div class="w-full bg-secondary opacity-80" style="height: 35%" title="OVER"></div>
-<div class="w-full bg-primary opacity-80" style="height: 60%" title="UNDER"></div>
-</div>
-<div class="flex justify-between mt-2 text-[8px] mono text-on-surface-variant">
-<span>00:00</span>
-<span>SCAN FLOW</span>
-<span>CURRENT</span>
-</div>
-</section>
-<!-- Results Table -->
-<section class="overflow-x-auto">
-<table class="w-full border-collapse">
-<thead>
-<tr class="bg-surface-container-highest text-left">
-<th class="p-2 text-[10px] uppercase font-label text-on-surface-variant whitespace-nowrap">Market / Question</th>
-<th class="p-2 text-[10px] uppercase font-label text-on-surface-variant text-right">Yes</th>
-<th class="p-2 text-[10px] uppercase font-label text-on-surface-variant text-right">No</th>
-<th class="p-2 text-[10px] uppercase font-label text-on-surface-variant text-right">Sum</th>
-<th class="p-2 text-[10px] uppercase font-label text-on-surface-variant text-right">Gap</th>
-</tr>
-</thead>
-<tbody class="text-xs">
-<!-- Row 1: Under -->
-<tr class="bg-surface-container-low border-b border-[#0e0e0e]">
-<td class="p-2 max-w-[120px]">
-<div class="flex items-center gap-1 mb-1">
-<span class="px-1 bg-on-primary-container text-[8px] mono text-primary">UNDER</span>
-</div>
-<div class="truncate text-on-surface font-medium">Will BTC hit 100k by EOY?</div>
-</td>
-<td class="p-2 text-right mono">0.45</td>
-<td class="p-2 text-right mono">0.52</td>
-<td class="p-2 text-right mono">0.97</td>
-<td class="p-2 text-right mono text-primary font-bold">-0.03</td>
-</tr>
-<!-- Row 2: Over -->
-<tr class="bg-surface-container border-b border-[#0e0e0e]">
-<td class="p-2 max-w-[120px]">
-<div class="flex items-center gap-1 mb-1">
-<span class="px-1 bg-secondary-container text-[8px] mono text-secondary">OVER</span>
-</div>
-<div class="truncate text-on-surface font-medium">Ethereum ETF Approval...</div>
-</td>
-<td class="p-2 text-right mono">0.58</td>
-<td class="p-2 text-right mono">0.47</td>
-<td class="p-2 text-right mono">1.05</td>
-<td class="p-2 text-right mono text-secondary font-bold">+0.05</td>
-</tr>
-<!-- Row 3: Under -->
-<tr class="bg-surface-container-low border-b border-[#0e0e0e]">
-<td class="p-2 max-w-[120px]">
-<div class="flex items-center gap-1 mb-1">
-<span class="px-1 bg-on-primary-container text-[8px] mono text-primary">UNDER</span>
-</div>
-<div class="truncate text-on-surface font-medium">Solana Breakpoint Anno...</div>
-</td>
-<td class="p-2 text-right mono">0.22</td>
-<td class="p-2 text-right mono">0.74</td>
-<td class="p-2 text-right mono">0.96</td>
-<td class="p-2 text-right mono text-primary font-bold">-0.04</td>
-</tr>
-<!-- Row 4: Over -->
-<tr class="bg-surface-container border-b border-[#0e0e0e]">
-<td class="p-2 max-w-[120px]">
-<div class="flex items-center gap-1 mb-1">
-<span class="px-1 bg-secondary-container text-[8px] mono text-secondary">OVER</span>
-</div>
-<div class="truncate text-on-surface font-medium">Fed Rate Hike Sept 2024</div>
-</td>
-<td class="p-2 text-right mono">0.89</td>
-<td class="p-2 text-right mono">0.18</td>
-<td class="p-2 text-right mono">1.07</td>
-<td class="p-2 text-right mono text-secondary font-bold">+0.07</td>
-</tr>
-<!-- Row 5: Under -->
-<tr class="bg-surface-container-low border-b border-[#0e0e0e]">
-<td class="p-2 max-w-[120px]">
-<div class="flex items-center gap-1 mb-1">
-<span class="px-1 bg-on-primary-container text-[8px] mono text-primary">UNDER</span>
-</div>
-<div class="truncate text-on-surface font-medium">GOP Nominee Prediction</div>
-</td>
-<td class="p-2 text-right mono">0.48</td>
-<td class="p-2 text-right mono">0.48</td>
-<td class="p-2 text-right mono">0.96</td>
-<td class="p-2 text-right mono text-primary font-bold">-0.04</td>
-</tr>
-</tbody>
-</table>
-</section>
-</main>
-<!-- BottomNavBar -->
-<nav class="fixed bottom-0 left-0 w-full flex justify-around items-center bg-[#0e0e0e] h-16 border-t border-[#201f1f] z-50">
-<a class="flex flex-col items-center justify-center text-[#00ff88] bg-[#131313] p-2 flex-1 h-full" href="#">
-<span class="material-symbols-outlined mb-1" data-icon="grid_view" style="font-variation-settings: 'FILL' 1;">grid_view</span>
-<span class="font-['Space_Grotesk'] text-[10px] uppercase">Terminal</span>
-</a>
-<a class="flex flex-col items-center justify-center text-gray-600 p-2 flex-1 h-full hover:text-[#00ff88]" href="#">
-<span class="material-symbols-outlined mb-1" data-icon="radar">radar</span>
-<span class="font-['Space_Grotesk'] text-[10px] uppercase">Scanners</span>
-</a>
-<a class="flex flex-col items-center justify-center text-gray-600 p-2 flex-1 h-full hover:text-[#00ff88]" href="#">
-<span class="material-symbols-outlined mb-1" data-icon="history">history</span>
-<span class="font-['Space_Grotesk'] text-[10px] uppercase">History</span>
-</a>
-<a class="flex flex-col items-center justify-center text-gray-600 p-2 flex-1 h-full hover:text-[#00ff88]" href="#">
-<span class="material-symbols-outlined mb-1" data-icon="settings">settings</span>
-<span class="font-['Space_Grotesk'] text-[10px] uppercase">Settings</span>
-</a>
+
+<!-- BOTTOM NAV -->
+<nav class="fixed bottom-0 left-0 right-0 flex z-40" style="background:#13111Aee;backdrop-filter:blur(12px);border-top:1px solid #2C2B3B">
+  <a href="#" class="flex-1 flex flex-col items-center py-3" style="color:#FC72FF">
+    <span class="material-symbols-outlined text-base">auto_awesome</span>
+    <span class="font-sans text-[9px] font-medium mt-0.5">Scanner</span>
+  </a>
+  <a href="#" class="flex-1 flex flex-col items-center py-3" style="color:#5E5E6E">
+    <span class="material-symbols-outlined text-base">history</span>
+    <span class="font-sans text-[9px] font-medium mt-0.5">History</span>
+  </a>
+  <a href="#" class="flex-1 flex flex-col items-center py-3" style="color:#5E5E6E">
+    <span class="material-symbols-outlined text-base">settings</span>
+    <span class="font-sans text-[9px] font-medium mt-0.5">Settings</span>
+  </a>
 </nav>
-<!-- Floating HUD Elements (Purely Aesthetic) -->
-<div class="fixed bottom-20 right-4 pointer-events-none">
-<div class="bg-surface-container-high border border-outline-variant p-2 flex flex-col items-end">
-<div class="flex items-center gap-1 text-[8px] mono text-primary">
-<span class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse"></span>
-                LIVE FEED
-            </div>
-<div class="text-[10px] mono text-on-surface-variant">LATENCY: 14ms</div>
-</div>
-</div>
-</body></html>
+
+<script>
+var activeDir = 'ALL';
+
+function setDir(dir, btn){
+  activeDir = dir;
+  document.querySelectorAll('.dir').forEach(function(b){
+    b.style.background = 'transparent';
+    b.style.color = '#9B9BA0';
+  });
+  btn.style.background = 'linear-gradient(135deg,#FC72FF,#9B51E0)';
+  btn.style.color = 'white';
+  applyFilter();
+}
+
+function applyFilter(){
+  var minGap = parseInt(document.getElementById('gap-slider').value);
+  var cards = document.querySelectorAll('#feed .signal-card');
+  var shown = 0;
+  cards.forEach(function(card){
+    var dir = card.dataset.dir;
+    var gap = parseInt(card.dataset.gap);
+    var ok = (activeDir === 'ALL' || dir === activeDir) && gap >= minGap;
+    card.style.display = ok ? '' : 'none';
+    if(ok) shown++;
+  });
+  document.getElementById('signal-count').textContent = shown;
+  document.getElementById('count-label').textContent = shown + ' signals';
+  document.getElementById('no-results').classList.toggle('hidden', shown > 0);
+}
+
+var newSignals = [
+  { dir:'OVER', title:'ADA Vasil Fork Launch?', yes:'0.610', no:'0.440', sum:'1.050', gap:5, net:3, ts:'just now' },
+  { dir:'UNDER', title:'XRP SEC Settled 2024?', yes:'0.380', no:'0.580', sum:'0.960', gap:4, net:2, ts:'just now' },
+  { dir:'OVER', title:'Arbitrum TVL > $5B?', yes:'0.720', no:'0.330', sum:'1.050', gap:5, net:3, ts:'just now' },
+];
+var ni = 0;
+
+function triggerScan(){
+  var btn = document.getElementById('scan-btn');
+  btn.innerHTML = '<span class="material-symbols-outlined text-sm">sync</span> Scanning...';
+  btn.style.opacity = '0.7';
+  btn.disabled = true;
+  setTimeout(function(){
+    btn.innerHTML = '<span class="material-symbols-outlined text-sm">radar</span> Scan';
+    btn.style.opacity = '1';
+    btn.disabled = false;
+    injectSignal();
+  }, 1800);
+}
+
+function injectSignal(){
+  var d = newSignals[ni % newSignals.length]; ni++;
+  var isUnder = d.dir === 'UNDER';
+  var color = isUnder ? '#40B66B' : '#FF5F52';
+  var bgColor = isUnder ? '#0D2218' : '#2A1212';
+  var borderColor = isUnder ? '#40B66B44' : '#FF5F5244';
+  var card = document.createElement('div');
+  card.className = 'signal-card rounded-2xl cursor-pointer transition-all duration-150';
+  card.style.cssText = 'background:#1B1A23;border:1px solid #2C2B3B';
+  card.dataset.dir = d.dir;
+  card.dataset.gap = d.gap;
+  card.innerHTML = `
+    <div class="flex items-start gap-3 p-3.5">
+      <div class="flex items-end gap-px h-9 w-10 shrink-0 self-end">
+        <div class="flex-1 rounded-t-sm opacity-40" style="height:40%;background:${color}"></div>
+        <div class="flex-1 rounded-t-sm opacity-70" style="height:70%;background:${color}"></div>
+        <div class="flex-1 rounded-t-sm" style="height:100%;background:${color}"></div>
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-1.5 mb-1.5">
+          <span class="px-2 py-0.5 rounded-full text-[9px] font-sans font-semibold" style="background:${bgColor};color:${color};border:1px solid ${borderColor}">${d.dir}</span>
+          <span class="text-[9px] font-mono" style="color:#5E5E6E">${d.ts}</span>
+          <span class="text-[9px] font-mono ml-auto animate-pulse" style="color:#FC72FF">⚡ new</span>
+        </div>
+        <div class="font-sans font-semibold text-[13px] truncate mb-1.5" style="color:#F5F4F5">${d.title}</div>
+        <div class="flex items-center gap-3 font-mono text-[9px]" style="color:#9B9BA0">
+          <span>Y <span style="color:#F5F4F5">${d.yes}</span></span>
+          <span>N <span style="color:#F5F4F5">${d.no}</span></span>
+          <span>Σ <span style="color:${color}" class="font-bold">${d.sum}</span></span>
+        </div>
+      </div>
+      <div class="shrink-0 text-right self-start">
+        <div class="font-mono text-xl font-bold leading-none" style="color:${color}">${d.gap}.0<span class="text-xs">%</span></div>
+        <div class="font-mono text-[9px] mt-0.5" style="color:#9B9BA0">net +${d.net}.0%</div>
+      </div>
+    </div>
+    <div class="mx-3.5 h-1 rounded-full mb-3" style="background:#22202E">
+      <div class="h-full rounded-full gap-bar" style="width:${d.gap*10}%;background:${color}88"></div>
+    </div>
+  `;
+  card.addEventListener('click', function(){ window.open('https://polymarket.com','_blank'); });
+  card.addEventListener('mouseenter', function(){ this.style.borderColor=color+'55'; this.style.boxShadow='0 0 16px '+color+'22'; });
+  card.addEventListener('mouseleave', function(){ this.style.borderColor='#2C2B3B'; this.style.boxShadow='none'; });
+  var feed = document.getElementById('feed');
+  feed.insertBefore(card, feed.firstChild);
+  document.getElementById('signal-count').textContent = parseInt(document.getElementById('signal-count').textContent) + 1;
+}
+</script>
+</body>
+</html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,32 +3,64 @@ export default {
   theme: {
     extend: {
       colors: {
-        "primary-fixed":     "#00fd87",
-        "primary-dim":       "#00ed7e",
-        "primary":           "#a4ffb9",
-        "on-primary":        "#003919",
-        "on-primary-container": "#005b2c",
-        "secondary":         "#ffb4ab",
-        "secondary-dim":     "#ff7169",
-        "secondary-container":"#8d1d1e",
-        "surface-lowest":    "#000000",
-        "surface-dim":       "#0e0e0e",
-        "surface":           "#131313",
-        "surface-low":       "#1c1b1b",
-        "surface-container": "#201f1f",
-        "surface-high":      "#2a2a2a",
-        "surface-highest":   "#353534",
-        "on-surface":        "#e5e2e1",
-        "on-surface-variant":"#b9cbb9",
-        "outline":           "#849585",
-        "outline-variant":   "#3b4b3d",
+        /* Backgrounds */
+        "bg-base":        "#0e0d14",
+        "bg-card":        "#22202e",
+        "bg-card-inner":  "#1a1826",
+        "bg-sidebar":     "#13121e",
+
+        /* Primary */
+        "primary":        "#33ff99",
+        "primary-hover":  "#00ccc9",
+        "on-primary":     "#000000",
+
+        /* Filter active */
+        "filter-active":  "#e566ff",
+        "on-filter":      "#000000",
+
+        /* Text */
+        "text-primary":   "#ffffff",
+        "text-secondary": "#c0c0c0",
+        "text-muted":     "#6b6882",
+
+        /* Badges */
+        "under-bg":       "#0d2218",
+        "under-text":     "#00fd87",
+        "over-bg":        "#2a1212",
+        "over-text":      "#ff5f52",
+
+        /* Borders */
+        "border-default": "#2e2c3e",
+        "border-subtle":  "#1e1d2b",
+
+        /* Legacy compat */
+        "surface":           "#0e0d14",
+        "surface-dim":       "#13121e",
+        "surface-low":       "#22202e",
+        "surface-container": "#1a1826",
+        "surface-high":      "#2e2c3e",
+        "surface-highest":   "#3a3850",
+        "on-surface":        "#ffffff",
+        "on-surface-variant":"#c0c0c0",
+        "outline":           "#6b6882",
+        "outline-variant":   "#2e2c3e",
+        "primary-fixed":     "#33ff99",
+        "primary-dim":       "#00ccc9",
+        "secondary":         "#ff5f52",
+        "secondary-container":"#2a1212",
       },
       fontFamily: {
-        mono: ['"JetBrains Mono"','monospace'],
-        sg:   ['"Space Grotesk"','sans-serif'],
-        body: ['Inter','sans-serif'],
+        mono: ['"JetBrains Mono"', 'monospace'],
+        sg:   ['"Space Grotesk"', 'sans-serif'],
+        body: ['Inter', 'sans-serif'],
       },
-      borderRadius: { DEFAULT:"0px", lg:"0px", xl:"0px", full:"9999px" },
+      borderRadius: {
+        DEFAULT: "6px",
+        sm: "4px",
+        lg: "8px",
+        full: "9999px",
+        none: "0px",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
อัปเดต UI ตาม Figma V2 design อย่างครบถ้วน

## Changes

### Design Tokens
- Background: `#0e0d14`, Cards: `#22202e`, Sidebar: `#13121e`
- Primary: `#33ff99`, Hover: `#00ccc9`
- Filter active: `#e566ff` (magenta)
- Border radius: 0px → 6px

### New Component
- **SignalCard** — sparkline bars, 44px gap %, net profit row, gradient progress bar
- UNDER badge: `bg #0d2218 / text #00fd87`
- OVER badge: `bg #2a1212 / text #ff5f52`

### Layout Changes
- Stats + Filters ย้ายเข้า desktop sidebar
- Cards / Table view toggle ใน ScannerPage
- Nav ลดเหลือ 3 items (Terminal, History, Settings)
- SCAN NOW button hover state ถูกต้องตาม spec

## Test Results
- ✅ Tests: 12/12 pass
- ✅ Build: zero TypeScript errors

## Preview
🌐 https://cancel-document-nancy-miami.trycloudflare.com

Closes #7