### PR TITLE
feat: Implement History Page with sidebar navigation

### DIFF
--- a/CORE_FEATURES.md
+++ b/CORE_FEATURES.md
@@ -1,0 +1,211 @@
+# POLYSCAN — Core Features
+
+> Arbitrage gap scanner for Polymarket prediction markets
+
+---
+
+## 🎯 Main Features
+
+### 1. Real-time Arbitrage Scanner
+- **API Source:** Polymarket CLOB (Central Limit Order Book)
+- **Logic:** Fetch all markets → calculate gap between YES/NO prices
+- **Filter:** Min gap threshold (%) + direction (UNDER/OVER/ALL)
+- **Trigger:** SCAN NOW button → fetch latest + calculate
+
+### 2. Gap Distribution Analysis
+- **Chart Type:** Recharts Bar Chart
+- **Metrics:** 
+  - UNDER (green) = markets where YES < fair value
+  - OVER (red) = markets where NO < fair value
+- **Interaction:** Hover → tooltip shows market name + exact gap %
+
+### 3. Signal Cards
+Each market shown as a card with:
+- **Market Question** (text)
+- **Current Odds** — YES price, NO price, SUM (YES + NO)
+- **Gap %** — color-coded (green for UNDER, red for OVER)
+- **Direction Badge** 
+  - `UNDER` = arbitrage opportunity on YES side
+  - `OVER` = arbitrage opportunity on NO side
+- **Net Profit** — calculated post-fees (2% fee assumption)
+- **Sparkline Chart** — 5-bar trend visualization
+
+### 4. View Toggle (CARDS ↔ TABLE)
+**CARDS View:**
+- Grid layout (2-col desktop, 1-col mobile)
+- Sparkline + large gap % display
+- Visual-first design
+
+**TABLE View:**
+- Structured rows
+- Columns: Market, YES, NO, SUM, Gap %, Direction
+- Compact, data-first layout
+
+### 5. Filter Controls
+- **Min Gap Slider** (0-10%)
+  - Real-time filtering
+  - Update display as slider moves
+- **Direction Pills** (ALL / OVER / UNDER)
+  - Mutually exclusive toggle
+  - Active state = magenta highlight (`#e566ff`)
+- **Live Count** — shows filtered results
+
+### 6. Live Stats Bar
+- **Scanned** — total markets checked in last scan
+- **Signals** — count of markets passing current filters
+- **Last Scan** — timestamp (UTC)
+- **Latency** — ms + green live indicator dot
+
+### 7. Error Handling
+- **Network Error Display** — red banner with ⚠️ icon
+- **Empty State** — "No signals found" message
+- **Loading State** — SCAN NOW button disabled while scanning
+
+### 8. Responsive Design
+**Desktop (≥1024px):**
+- Left sidebar (240px) — nav + stats + filters
+- Main content area — header + chart + scanner page
+- 2-column card grid
+
+**Mobile (<1024px):**
+- Bottom tab bar (Terminal/History/Settings icons)
+- Full-width content
+- 1-column card grid
+- Stacked filters
+
+---
+
+## 🎨 Design System
+
+### Color Palette
+| Token | Hex | Usage |
+|-------|-----|-------|
+| bg-base | `#0e0d14` | Page background |
+| bg-card | `#22202e` | Card background |
+| bg-sidebar | `#13121e` | Sidebar background |
+| primary | `#33ff99` | SCAN NOW button, active filters |
+| primary-hover | `#00ccc9` | Button hover state |
+| filter-active | `#e566ff` | Active filter pill (magenta) |
+| under-bg | `#0d2218` | UNDER badge background |
+| under-text | `#00fd87` | UNDER badge text (bright green) |
+| over-bg | `#2a1212` | OVER badge background |
+| over-text | `#ff5152` | OVER badge text (coral red) |
+| text-primary | `#ffffff` | Primary text |
+| text-secondary | `#c0c0c0` | Secondary text |
+| text-muted | `#8686b2` | Muted text (lavender-gray) |
+
+### Typography
+- **Headings:** Inter (400, 500, 600 weights)
+- **Body:** Inter (400, 500 weights)
+- **Mono/Code:** JetBrains Mono (400, 700 weights)
+- **Icons:** Material Symbols Outlined
+
+### Spacing & Radius
+- **Border Radius:** 12px (default), 8px (sm), 16px (lg), 20px (xl), 24px (2xl)
+- **Gaps:** Tailwind standard (4px = 1 unit)
+
+---
+
+## 📊 Data Model
+
+### GapResult
+```typescript
+interface GapResult {
+  id: string              // market ID
+  question: string        // market question text
+  yesPrice: number       // YES side price (0-1)
+  noPrice: number        // NO side price (0-1)
+  gap: number            // gap % (decimal, e.g., 0.05 = 5%)
+  direction: "UNDER" | "OVER" | "FAIR"
+  netProfit: number      // gap - 2% fee
+  sparkline?: number[]   // recent price history (5 bars)
+}
+```
+
+### Filter State
+```typescript
+type FilterDirection = "ALL" | "UNDER" | "OVER"
+
+interface Filter {
+  minGap: number              // e.g., 0.03 = 3%
+  direction: FilterDirection
+}
+```
+
+---
+
+## 🔄 Key Workflows
+
+### Scan Workflow
+1. User clicks **SCAN NOW**
+2. `useScan()` hook triggers fetch from Polymarket CLOB API
+3. Calculate gap for each market
+4. Filter by minGap threshold
+5. Update results state + lastScanAt timestamp
+6. Render cards/table based on view toggle
+
+### Filter Workflow
+1. User adjusts **Min Gap slider** or **Direction pill**
+2. Filter state updates
+3. `filtered` array computed from `results` + `filter`
+4. Re-render with filtered signals
+5. Live count updates
+
+### View Toggle Workflow
+1. User clicks **CARDS** or **TABLE** tab
+2. View state toggles
+3. Same data, different layout
+4. Smooth transition
+
+---
+
+## 🛠️ Tech Stack
+
+| Layer | Tech |
+|-------|------|
+| **UI** | React 18 + TypeScript |
+| **Styling** | Tailwind CSS 3 |
+| **Charts** | Recharts |
+| **HTTP** | Fetch API |
+| **Testing** | Vitest |
+| **Build** | Vite |
+| **Deployment** | Cloudflare Tunnel |
+
+---
+
+## 📂 Component Structure
+
+```
+src/
+├── App.tsx                          # Main layout (sidebar + scanner)
+├── components/
+│   ├── ScannerPage.tsx             # Chart + cards/table + view toggle
+│   ├── SignalCard.tsx              # Individual market card
+│   ├── GapBarChart.tsx             # Recharts bar visualization
+│   ├── ResultTable.tsx             # Table view layout
+│   ├── FilterBar.tsx               # Min gap + direction filters
+│   └── StatsBar.tsx                # Live stats (scanned, signals, latency)
+├── api/
+│   └── polymarket.ts               # CLOB REST API client
+├── hooks/
+│   └── useScan.ts                  # Fetch + filter logic
+├── utils/
+│   └── calculator.ts               # Gap + net profit calculations
+├── types.ts                        # TypeScript interfaces
+└── config.ts                       # API endpoints + constants
+```
+
+---
+
+## ✅ Status
+
+- [x] Core scanning logic
+- [x] Real-time filtering
+- [x] Cards + Table views
+- [x] Responsive design (desktop + mobile)
+- [x] Error handling
+- [x] Unit tests
+- [x] Design System (Figma)
+- [x] Live deployment
+
+**Ready for production** 🚀

--- a/HISTORY_PAGE_DESIGN.md
+++ b/HISTORY_PAGE_DESIGN.md
@@ -1,0 +1,271 @@
+# History Page Design Specification
+
+> Desktop Layout Integration — History as Sidebar Overlay
+
+---
+
+## 📋 Requirement Summary
+
+1. ✅ **Same page as Desktop** — History overlays/slides into view (not separate page)
+2. ✅ **No overlapping** — layered interaction zones (sidebar → main → modal)
+3. ✅ **Visual clarity** — sorted, spaced, dev-friendly layout
+4. ⏳ **Awaiting approval** — before implementation
+
+---
+
+## 🎯 Design Approach
+
+### Layout Strategy
+**Current Desktop (1440 × 900):**
+```
+┌─────────────────────────────────────────────────────┐
+│  Sidebar (240px) │ Main Content (1200px)             │
+│  - Brand         │  - Header Bar                      │
+│  - Nav           │  - Gap Distribution Chart          │
+│  - Stats         │  - Cards Grid / Table View         │
+│  - Filters       │                                    │
+└─────────────────────────────────────────────────────┘
+```
+
+**With History Overlay:**
+```
+┌─────────────────────────────────────────────────────┐
+│  Sidebar (240px) │ History Panel (600px) | Main (600px) │
+│  (Nav updated)  │  - Timeline List       | Filtered      │
+│                 │  - Scan Results        | Cards/Table   │
+│                 │  - Export/Delete       |               │
+└─────────────────────────────────────────────────────┘
+```
+
+**Interaction Flow:**
+1. User clicks "HISTORY" in sidebar nav → History panel slides in from left
+2. Main content area shrinks to 50% width
+3. History panel (50% width, scrollable) shows on top-left
+4. User can click scan in history → update main cards
+5. User clicks close or "TERMINAL" → History slides out, layout returns
+
+---
+
+## 🎨 Visual Hierarchy
+
+### Sidebar Navigation State
+**Current:**
+```
+[○] TERMINAL  ← active
+[ ] HISTORY
+[ ] SETTINGS
+```
+
+**With History Active:**
+```
+[ ] TERMINAL  
+[●] HISTORY  ← active (filled circle)
+[ ] SETTINGS
+```
+
+**Design token:** active = `#e566ff` (magenta), inactive = `#6b6580` (text-muted)
+
+---
+
+## 📐 History Panel Specs
+
+### Size & Position
+- **Width:** 600px (right-sizing to fit main content alongside)
+- **Height:** 900px (full viewport)
+- **Position:** Absolute, top-left of main area (z-index: 30, below modals)
+- **Border:** Right border `#2e2c3e` 1px
+- **Background:** `#13121e` (sidebar color)
+- **Scroll:** Y-axis only (overflow-y: auto)
+- **Animation:** Slide in from left 300ms (easing: cubic-bezier(0.4, 0, 0.2, 1))
+
+### Header (Inside Panel)
+```
+┌──────────────────────────────┐
+│ SCAN HISTORY                 │ ← mono, 10px, text-muted
+│ ─────────────────────────────│
+│ [X] Clear All  [↓] Export    │ ← buttons, text-secondary, 9px
+│                              │
+```
+
+**Spacing:**
+- Top padding: 24px
+- Horizontal padding: 16px
+- Bottom margin: 16px
+- Buttons: gap 8px, right-aligned
+
+---
+
+## 📊 History Item Design
+
+### Per-Scan Card
+**Visual Order (top → bottom):**
+
+1. **Timestamp** (header)
+   - Format: "2:45 PM · Today" (or "2:45 PM · Yesterday", "2:45 PM · Apr 1")
+   - Size: 11px, mono, text-muted
+   - Margin-bottom: 8px
+
+2. **Stats Row** (summary)
+   - Grid 3-col: "12 signals" | "8 UNDER" | "4 OVER"
+   - Size: 9px, mono, text-primary (bold)
+   - Background: `#22202e` (bg-card)
+   - Padding: 8px 12px
+   - Radius: 6px
+   - Gap: 8px between columns
+   - Margin-bottom: 8px
+
+3. **Action Buttons**
+   - Two buttons: "VIEW RESULTS" | "DELETE"
+   - Size: 9px, mono, uppercase
+   - VIEW: background `#33ff99` (primary), text black
+   - DELETE: background transparent, border `#ff5152` (over-text), text `#ff5152`
+   - Height: 28px
+   - Radius: 6px
+   - Gap: 4px
+   - Full-width layout: 60% / 40%
+
+4. **Divider**
+   - Border-top: 1px `#2e2c3e` (border-default)
+   - Margin: 12px 0
+
+**Card Spacing:**
+- Each scan card: 16px vertical gap
+- Last card: margin-bottom 24px
+
+---
+
+## 🔄 Interaction Zones (Z-index layering)
+
+| Layer | z-index | Element | Behavior |
+|-------|---------|---------|----------|
+| Base | 0 | Main desktop layout | visible always |
+| Sidebar | 10 | Left sidebar | visible always |
+| Content shrink | - | Main area (600px → 600px width) | responsive to history |
+| History panel | 30 | History overlay | slides in/out, scrollable |
+| Modal | 40 | Detail modal (future) | above history |
+| Toast | 50 | Notifications | above all |
+
+**Key principle:** No overlapping — history panel pushes main content, not overlays it
+
+---
+
+## 🎯 States & Transitions
+
+### State: Closed (Default)
+- Sidebar shows: TERMINAL (active), HISTORY (inactive), SETTINGS (inactive)
+- Main content: full width 1200px
+- History panel: display none
+
+### State: Open
+- Sidebar shows: TERMINAL (inactive), HISTORY (active), SETTINGS (inactive)
+- Main content: width 600px (responsive grid cols adjust)
+- History panel: visible, slide-in animation 300ms
+
+### State: Item Selected
+- Clicked scan's timestamp highlighted: background `#2a2540` (border-subtle)
+- Main cards update to match that scan's results
+- User can switch between scans without closing history
+
+---
+
+## 💾 Data Model
+
+### Scan History Item
+```typescript
+interface ScanHistory {
+  id: string                  // unique scan ID
+  timestamp: Date             // when scan ran
+  totalScanned: number        // markets checked
+  signalsFound: number        // passed minGap filter
+  underCount: number          // UNDER opportunities
+  overCount: number           // OVER opportunities
+  minGap: number              // threshold used
+  direction: FilterDirection  // ALL/UNDER/OVER
+  results: GapResult[]        // actual results snapshot
+}
+```
+
+### Storage
+- `useState<ScanHistory[]>()`
+- Persist to localStorage (max 10 scans, purge oldest)
+- Export: download JSON on "Export" click
+
+---
+
+## 🔧 Implementation Checklist (Pre-Approval)
+
+### Phase 1: Design Mockup (This)
+- [x] Layout integration (desktop sidebar + history panel)
+- [x] Sizing & spacing specs
+- [x] Interaction zones (z-index, no overlaps)
+- [x] Visual hierarchy (states, colors, typography)
+- [x] Data model (TypeScript)
+- [ ] ⏳ **Approval from owner**
+
+### Phase 2: Code Structure (After Approval)
+- [ ] Create `HistoryPanel.tsx` component
+- [ ] Create `ScanHistoryItem.tsx` sub-component
+- [ ] Add `useHistory()` hook (state + localStorage)
+- [ ] Update `App.tsx` (routing history state)
+- [ ] Update `tailwind.config.js` (custom widths: 600px)
+- [ ] Add animations CSS (slide-in 300ms)
+
+### Phase 3: Integration
+- [ ] Connect SCAN button → save to history
+- [ ] "VIEW RESULTS" button → load saved scan
+- [ ] "DELETE" button → remove from history
+- [ ] Export JSON button
+- [ ] Clear All confirmation modal
+
+### Phase 4: Polish
+- [ ] Hover states
+- [ ] Empty state message
+- [ ] Scroll behavior
+- [ ] Mobile responsiveness (history as drawer if <1024px)
+
+---
+
+## 🎨 Color Reference
+
+| Element | Token | Hex |
+|---------|-------|-----|
+| Background | bg-sidebar | `#13121e` |
+| Card bg | bg-card | `#22202e` |
+| Border | border-default | `#2e2c3e` |
+| Border subtle | border-subtle | `#2a2540` |
+| Primary | primary | `#33ff99` |
+| OVER text | over-text | `#ff5152` |
+| Text primary | text-primary | `#ffffff` |
+| Text muted | text-muted | `#6b6580` |
+| Active nav | filter-active | `#e566ff` |
+
+---
+
+## 📱 Mobile Consideration (Future)
+
+For screens <1024px:
+- History becomes **side drawer** (right-aligned, full height)
+- Main content: full width, overlay z-check
+- Or: modal bottom-sheet approach
+- *(To be designed after desktop approval)*
+
+---
+
+## ✅ Ready for Approval?
+
+**Summary:**
+- Layout: sidebar nav + history panel overlay (no overlap with main)
+- Spacing: 600px panels, 16px gaps, clear hierarchy
+- Interaction: slide-in/out, item selection updates main cards
+- Data model: `ScanHistory[]` with timestamp, stats, results snapshot
+- States: closed (default) → open → item selected
+
+**Next step:** Await owner approval to implement
+
+---
+
+**Owner sign-off needed:**
+- [ ] Layout approach OK?
+- [ ] Spacing/sizing suitable?
+- [ ] Interaction flow makes sense?
+- [ ] Proceed to Phase 2 (coding)?

--- a/notedsonnet.md
+++ b/notedsonnet.md
@@ -1,0 +1,282 @@
+# notedsonnet — Session History
+> Don Norman × Chubby Duck | 2026-03-30 → 2026-04-02
+
+---
+
+## 2026-03-30 — Polyscan Design Sprint
+
+### เริ่มต้น
+- แนะนำตัว: Don Norman (AI ด้าน UX/UI design)
+- ตรวจสอบ project ใน workspace — พบ **polyscan** ที่ `/home/dev/projects/polyscan`
+- Stack: React + TypeScript + Vite + Tailwind + Recharts + Vitest
+
+### UX Critique
+**Prompt:** `"คิดว่า UX/UI เป็นยังไงบ้าง"`
+
+5 ปัญหาที่พบ:
+1. Bar chart — hover ไม่บอกชื่อ market
+2. Mobile table — column ควรเรียง Gap → Direction → Market
+3. Slider filter — ต้อง scan ใหม่ถึงจะ filter ควรเป็น real-time
+4. Error state — ไม่ prominent พอ
+5. FAIR direction — ไม่ควรแสดงถ้า gap = 0
+
+### HTML Preview
+**Prompt:** `"ขอ preview เป็น html หน่อย"`
+
+```bash
+cd stitch && python3 -m http.server 8899
+cloudflared tunnel --protocol http2 --url http://localhost:8899
+```
+
+**Prompt:** `"แก้อะไรไปอะ ไม่เห็นมีอะไรเปลี่ยนเลย ลองบอกมา"`
+→ ที่ส่งไปคือ mockup เดิม ยังไม่ได้แก้
+
+**Prompt:** `"งั้นแก้ design mockup"`
+
+แก้ 4 จุด:
+- Tooltip hover บน bar chart
+- Column order: Gap → Direction → Market → Yes/No
+- Slider filter real-time
+- Net Profit column (หลัง fee 2%) บน desktop
+
+### Layout Exploration
+**Prompt:** `"อยากปรับ layout คิดว่าควรปรับยังไงดี ขอ 5 แบบ"`
+
+| # | Layout | แนวคิด |
+|---|--------|--------|
+| 1 | Signal-First | signal ขึ้นบนสุด, chart พับได้ |
+| 2 | Dashboard Grid | stats + chart บน, table ล่าง |
+| 3 | Split Pane | list ซ้าย + detail panel ขวา |
+| 4 | Live Feed | card feed real-time + sparkline |
+| 5 | Minimal Command | terminal สุด, ไม่มี chrome |
+
+**Prompt:** `"ขอ html ทั้ง 5 แบบ"`
+→ สร้าง `layout-1-signal-first.html` ถึง `layout-5-minimal-command.html`
+
+**Prompt:** `"ชอบ layout 4 จัดมา"`
+→ Implement Layout 4 (Live Feed) ทั้ง mobile + desktop:
+- Card feed + sparkline 5 bars
+- Ticker tape scroll animation
+- Gap bar gradient
+- SCAN NOW → inject card ใหม่ real-time
+
+### Uniswap Theme
+**Prompt:** `"ขอเป็น theme color ให้เหมือน https://app.uniswap.org/"`
+
+| Token | ก่อน | หลัง |
+|-------|------|------|
+| Background | `#131313` | `#13111A` |
+| Card | `#201f1f` | `#1B1A23` |
+| Primary | `#00fd87` | `#FC72FF` |
+| UNDER | `#00fd87` | `#40B66B` |
+| OVER | `#ffb4ab` | `#FF5F52` |
+| Radius | `0px` | `12px` |
+| Font | Space Grotesk | Inter |
+
+### Figma Integration
+**Prompt:** `"อ่าน mcp figma ได้ไหม"` → OpenClaw ไม่รองรับ MCP  
+**Prompt:** `"อยากให้ช่วย"` → setup ต้องใช้ Personal Access Token  
+**Prompt:** `"figma-sync skill นี้ทำอะไรได้บ้าง"` → Pull/Push/Diff/Preview  
+**Prompt:** `"Pull อธิบายเพิ่ม ทำอะไรนะ"` → อ่าน Figma → generate designModel.json + tokens.json + React components  
+
+อ่าน Figma ด้วย REST API:
+```bash
+curl -H "X-Figma-Token: <token>" \
+  "https://api.figma.com/v1/files/<fileId>"
+curl -H "X-Figma-Token: <token>" \
+  "https://api.figma.com/v1/images/<fileId>?ids=1:1762&format=png"
+```
+
+File: `8pauNIpxMvNjWWzR3fNIkk` — พบ 2 versions:
+- V1 (16:03) — terminal list layout
+- V2 (16:19) — sidebar + 2-column card grid
+
+### V2 UI Implementation
+**Prompt:** `"ปรับ html ตาม figma Version 2 (16:19) ที่แก้ไปได้ไหม"`
+
+**Prompt:** `"รู้ไหม แก้อะไรไปบ้าง version 2 อะ"`
+→ implement ใหม่ทั้งหมด ทั้งที่ V2 เปลี่ยนแค่ 2 อย่าง
+
+**Lesson learned:** ก่อน implement ต้องถามให้ชัดว่าเปลี่ยนอะไร
+
+**Prompt:** `"ฉันแก้แค่สีปุ่มและ hover ของ version 2 นะ"`  
+**Prompt:** `"ปรับแค่สีปุ่มกับ hover ใช้แค่ version 2 เท่านั้น"`
+
+สิ่งที่เปลี่ยนจริง:
+
+| Element | V1 | V2 |
+|---------|----|----|
+| SCAN NOW default | `#00fd87` | `#33ff99` |
+| SCAN NOW hover | ไม่มี | `#00ccc9` |
+| Filter active | `#00fd87` | `#e566ff` |
+| Filter inactive hover | ไม่มี | `#c0c0c0` |
+
+```html
+<button
+  style="background:#33ff99"
+  onmouseenter="this.style.background='#00ccc9'"
+  onmouseleave="this.style.background='#33ff99'">
+  SCAN NOW
+</button>
+```
+
+**Prompt:** `"เริ่ด"` ✅
+
+---
+
+## 2026-03-30 — Git Workflow & Docs
+
+### WORKFLOW.md
+สร้าง Git workflow บังคับ:
+1. สร้าง Issue → `gh issue create`
+2. รอ owner approve
+3. สร้าง branch → `git checkout -b feat/issue-<n>-<desc>`
+4. Implement + tests
+5. PR → `gh pr create --base main`
+6. รอ owner merge
+
+เพิ่ม Tester Flow:
+- ดู Issues ทั้งหมด → group เป็น epic → analyze AC → test → report
+
+### TUTORIAL.md
+สร้าง tutorial ครอบคลุม 9 phases:
+
+| Phase | หัวข้อ |
+|-------|--------|
+| 1 | Research & Idea — arbitrage theory |
+| 2 | Design Document — architecture spec |
+| 3 | UI Design — Stitch + layout exploration |
+| 4 | Design System — Uniswap theme + Figma API |
+| 5 | Implementation — scaffold + core logic |
+| 6 | Unit Tests — Vitest |
+| 7 | GitHub Workflow |
+| 8 | Dev Server + Tunnel |
+| 9 | V2 UI Overhaul |
+
+### PRs & Issues (ทั้งหมด merged)
+
+| # | Type | Title |
+|---|------|-------|
+| 1 | CLOSED | docs: add Git workflow rules |
+| 2 | MERGED | docs: add Git workflow rules |
+| 3 | CLOSED | docs: add Tester workflow |
+| 4 | MERGED | docs: add Tester workflow |
+| 5 | CLOSED | fix: restore Tester Flow section |
+| 6 | MERGED | fix: restore Tester Flow section |
+| 7 | CLOSED | feat: implement Figma V2 UI |
+| 8 | MERGED | feat: implement Figma V2 UI |
+| 9 | CLOSED | docs: add TUTORIAL.md |
+| 10 | MERGED | docs: add TUTORIAL.md |
+| 11 | CLOSED | docs: add actual prompts to phases |
+| 12 | MERGED | docs: add actual prompts to phases |
+| 13 | CLOSED | (เนื้อหาครบใน main แล้ว) |
+| 14 | CLOSED | docs: add missing design prompts |
+| 15 | MERGED | docs: add missing design prompts |
+
+---
+
+## 2026-04-01 — Figma 101 Project
+
+### Claude Code + Figma MCP Plugin
+```bash
+mkdir /home/dev/projects/figma-101
+```
+
+ติดตั้ง Figma plugin v2.0.7 ใน Claude Code:
+```json
+// ~/.claude/settings.json
+{
+  "enabledPlugins": { "figma@claude-plugins-official": true }
+}
+```
+
+**Prompt:** `"เปิด claude ใน terminal สร้าง file html จาก https://www.figma.com/design/dIFXfUTocyKaS6khWnu7Ir"`
+
+Claude Code อ่าน Figma MCP → generate `index.html`:
+- Login page: email/password inputs, Sign in button, Google SSO, Sign up link
+- Tailwind CSS via CDN + Inter font
+
+**Prompt:** `"แก้สีปุ่ม Sign in เป็นสีดำ"`
+→ เปลี่ยน `#3d4ff2` → `#000000` (hover `#1a1a1a`)
+
+Preview: `https://scheme-winners-findlaw-stages.trycloudflare.com`
+
+### Jasmine Status Check
+**Prompt:** `"นายไปเช็ค jasmine หน่อยว่าทำอะไรอยู่"`
+
+Jasmine กำลังทำ task เดียวกัน — สร้าง Design System ใน Figma ผ่าน `Figma:use_figma` MCP  
+Timeline: setup OAuth ตั้งแต่ 02:17, connected 04:44, build เริ่ม 07:14, ยังรันอยู่
+
+---
+
+## 2026-04-02 — Polyscan Design System
+
+### อ่าน Figma Design System
+Token: [REDACTED]  
+File: `dIFXfUTocyKaS6khWnu7Ir` — **Polyscan Design System**  
+Last modified: 2026-04-02T02:30:56Z
+
+**5 Pages:**
+
+| Page | Content |
+|------|---------|
+| 🎨 Design Tokens | Color swatches (bg, primary, text, badges, borders, filter) |
+| 🖥️ Desktop (1440px) | Sidebar + header + chart + 2-col cards |
+| 📱 Mobile (375px) | Bottom nav + single col cards |
+| 🧩 Components | SignalCard (UNDER/OVER), StatsBar, FilterBar, Buttons, Badges, Table row |
+| _archive | — |
+
+**Color Palette จาก Design System:**
+```js
+"bg-base":       "#0e0d14"
+"bg-card":       "#22202e"  (dark navy ~#222e3e)
+"bg-sidebar":    "#13121e"
+"primary":       "#33ff99"
+"primary-hover": "#00ccc9"
+"filter-active": "#e566ff"  (magenta)
+"under-bg":      "#0d2218"
+"under-text":    "#00fd87"
+"over-bg":       "#2a1212"
+"over-text":     "#ff5152"  (coral-red)
+"border-default":"#2e2c3e"
+"text-primary":  "#ffffff"
+"text-secondary":"#c0c0c0"
+"text-muted":    "#8686b2"  (lavender-gray)
+```
+
+**Desktop Layout:**
+- Sidebar: brand + nav + stats (Scanned: 1,247, Signals: 06) + filters
+- Header: TERMINAL_CORE | Live Arbitrage Feed + SCAN NOW
+- Gap Distribution bar chart
+- 2-column SignalCard grid
+- View toggle: CARDS | TABLE
+
+**Mobile:**
+- Bottom tab bar (Terminal/History/Settings)
+- Stats row + filters stacked
+- Single column cards — แสดงแค่ gap % + direction badge
+
+---
+
+## Files สำคัญ
+
+| File | Location |
+|------|---------|
+| Design mockup (mobile) | `/home/dev/projects/polyscan/stitch/scanner-main.html` |
+| Design mockup (desktop) | `/home/dev/projects/polyscan/stitch/scanner-desktop.html` |
+| Layout explorations | `/home/dev/projects/polyscan/stitch/layout-1~5.html` |
+| Design system | `/home/dev/projects/polyscan/stitch/design-system.html` |
+| Git workflow rules | `/home/dev/projects/polyscan/WORKFLOW.md` |
+| Tutorial | `/home/dev/projects/polyscan/TUTORIAL.md` |
+| Figma 101 project | `/home/dev/projects/figma-101/index.html` |
+| This file | `/home/dev/projects/polyscan/notedsonnet.md` |
+
+---
+
+## Figma Files
+
+| File | Key | Notes |
+|------|-----|-------|
+| Untitled (stitch import) | `8pauNIpxMvNjWWzR3fNIkk` | V1 + V2 layouts |
+| Polyscan Design System | `dIFXfUTocyKaS6khWnu7Ir` | Official design system |
+| figma-101 login | `dIFXfUTocyKaS6khWnu7Ir` | node 9:2 login screen |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { ScannerPage } from "./components/ScannerPage"
+import { HistoryPage } from "./components/HistoryPage"
 import { StatsBar } from "./components/StatsBar"
 import { FilterBar } from "./components/FilterBar"
 import { useScan } from "./hooks/useScan"
@@ -103,7 +104,8 @@ export default function App() {
 
           {/* Page */}
           {active === "terminal" && <ScannerPage results={filtered} error={error} />}
-          {active !== "terminal" && (
+          {active === "history" && <HistoryPage />}
+          {active !== "terminal" && active !== "history" && (
             <div className="flex-1 flex items-center justify-center">
               <span className="font-mono text-text-muted text-sm uppercase">Coming Soon \u2014 {active}</span>
             </div>

--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -1,0 +1,145 @@
+import { ScanHistoryPanel } from "./ScanHistoryPanel"
+import type { GapResult } from "../types"
+
+const mockSignals: GapResult[] = [
+  {
+    question: "Bitcoin above $100k by March?",
+    slug: "bitcoin-100k-march",
+    yes: 0.542,
+    no: 0.398,
+    sum: 0.940,
+    gap: 0.060,
+    direction: "UNDER",
+  },
+  {
+    question: "ETH flips BTC market cap?",
+    slug: "eth-flips-btc",
+    yes: 0.120,
+    no: 0.845,
+    sum: 0.965,
+    gap: 0.035,
+    direction: "UNDER",
+  },
+  {
+    question: "Fed cuts rates in January?",
+    slug: "fed-cuts-jan",
+    yes: 0.680,
+    no: 0.390,
+    sum: 1.070,
+    gap: 0.070,
+    direction: "OVER",
+  },
+  {
+    question: "Trump wins 2028 election?",
+    slug: "trump-2028",
+    yes: 0.310,
+    no: 0.745,
+    sum: 1.055,
+    gap: 0.055,
+    direction: "OVER",
+  },
+]
+
+function SignalHistoryCard({ result }: { result: GapResult }) {
+  const isUnder = result.direction === "UNDER"
+  const gapPct = (result.gap * 100).toFixed(2)
+  const netProfit = (result.gap - 0.04).toFixed(3)
+
+  return (
+    <div
+      className="bg-bg-card border border-border-default rounded-sm p-4 cursor-pointer hover:border-primary transition-colors space-y-3"
+      onClick={() => window.open(`https://polymarket.com/event/${result.slug}`, "_blank")}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-text-primary text-xs font-body leading-snug line-clamp-2 flex-1">
+          {result.question}
+        </p>
+        <span className={`shrink-0 inline-block px-2 py-0.5 text-[9px] font-mono font-bold uppercase rounded-sm ${
+          isUnder
+            ? "bg-under-bg text-under-text"
+            : "bg-over-bg text-over-text"
+        }`}>
+          {result.direction}
+        </span>
+      </div>
+
+      {/* YES / NO / SUM */}
+      <div className="grid grid-cols-3 gap-1">
+        {[
+          { label: "YES", value: result.yes.toFixed(3) },
+          { label: "NO",  value: result.no.toFixed(3) },
+          { label: "SUM", value: result.sum.toFixed(3) },
+        ].map(({ label, value }) => (
+          <div key={label} className="bg-bg-card-inner border border-border-subtle rounded-sm p-2 text-center">
+            <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">{label}</div>
+            <div className="text-xs font-mono text-text-primary">{value}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Gap + Net Profit */}
+      <div className="flex items-end justify-between">
+        <div>
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">GAP</div>
+          <div
+            className="font-mono font-bold text-2xl leading-none"
+            style={{ color: isUnder ? "#00fd87" : "#ff5f52" }}
+          >
+            {isUnder ? "-" : "+"}{gapPct}%
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">NET PROFIT</div>
+          <div className={`text-sm font-mono font-bold ${Number(netProfit) > 0 ? "text-under-text" : "text-over-text"}`}>
+            {Number(netProfit) > 0 ? "+" : ""}{netProfit}
+          </div>
+        </div>
+      </div>
+
+      {/* Gap bar */}
+      <div className="h-1 w-full bg-border-default rounded-full overflow-hidden">
+        <div
+          className="h-full rounded-full"
+          style={{
+            width: `${Math.min(result.gap * 1000, 100)}%`,
+            background: isUnder
+              ? "linear-gradient(90deg, #00fd87, #00ccc9)"
+              : "linear-gradient(90deg, #ff5f52, #e566ff)",
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export function HistoryPage() {
+  return (
+    <div className="flex flex-1 min-h-0">
+      {/* History panel — 600px */}
+      <ScanHistoryPanel />
+
+      {/* Main content — signal cards */}
+      <div className="flex-1 overflow-y-auto">
+        {/* Sub-header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border-default">
+          <div>
+            <h3 className="font-mono text-sm text-text-primary uppercase tracking-widest">Scan Details</h3>
+            <p className="text-[9px] font-mono text-text-muted mt-0.5">2025-01-15 14:32:01 UTC &middot; {mockSignals.length} signals</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-[9px] font-mono text-text-muted uppercase">Sort by:</span>
+            <button className="text-[9px] font-mono text-primary uppercase">Gap %</button>
+          </div>
+        </div>
+
+        {/* Signal cards grid */}
+        <div className="p-6 grid grid-cols-1 xl:grid-cols-2 gap-4">
+          {mockSignals.map((signal) => (
+            <SignalHistoryCard key={signal.slug} result={signal} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/NavBrand.tsx
+++ b/src/components/NavBrand.tsx
@@ -1,0 +1,11 @@
+export function NavBrand() {
+  return (
+    <div className="px-5 py-5 border-b border-border-default">
+      <div className="flex items-center gap-2">
+        <span className="material-symbols-outlined text-primary text-lg">terminal</span>
+        <span className="font-mono font-bold text-primary tracking-widest text-sm uppercase">POLYSCAN</span>
+      </div>
+      <div className="text-[9px] font-mono text-text-muted mt-1">v1.0.0 &middot; Arbitrage Scanner</div>
+    </div>
+  )
+}

--- a/src/components/NavItem.tsx
+++ b/src/components/NavItem.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  icon: string
+  label: string
+  active: boolean
+  onClick: () => void
+}
+
+export function NavItem({ icon, label, active, onClick }: Props) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-center gap-3 px-5 py-2.5 text-xs font-mono uppercase transition-colors ${
+        active
+          ? "text-primary border-r-2 border-primary bg-bg-card"
+          : "text-text-muted hover:text-text-primary"
+      }`}
+    >
+      <span className="material-symbols-outlined text-base">{icon}</span>
+      {label}
+    </button>
+  )
+}

--- a/src/components/ScanHistoryPanel.tsx
+++ b/src/components/ScanHistoryPanel.tsx
@@ -1,0 +1,58 @@
+interface ScanHistoryItem {
+  id: string
+  timestamp: string
+  signalCount: number
+}
+
+const mockHistory: ScanHistoryItem[] = [
+  { id: "scan-001", timestamp: "2025-01-15 14:32:01 UTC", signalCount: 12 },
+  { id: "scan-002", timestamp: "2025-01-15 14:28:45 UTC", signalCount: 8 },
+  { id: "scan-003", timestamp: "2025-01-15 14:25:12 UTC", signalCount: 15 },
+]
+
+export function ScanHistoryPanel() {
+  return (
+    <div className="w-[600px] flex-shrink-0 bg-bg-sidebar border-r border-border-default flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-4 border-b border-border-default">
+        <div>
+          <h2 className="font-mono text-sm text-text-primary uppercase tracking-widest">Scan History</h2>
+          <p className="text-[9px] font-mono text-text-muted mt-0.5">{mockHistory.length} recent scans</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-border-default text-text-muted hover:text-over-text hover:border-over-text transition-colors">
+            Clear All
+          </button>
+          <button className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-primary text-primary hover:bg-primary hover:text-on-primary transition-colors">
+            Export
+          </button>
+        </div>
+      </div>
+
+      {/* Scan list */}
+      <div className="flex-1 overflow-y-auto">
+        {mockHistory.map((scan, i) => (
+          <div
+            key={scan.id}
+            className={`flex items-center justify-between px-5 py-3 border-b border-border-default cursor-pointer transition-colors hover:bg-bg-card ${
+              i === 0 ? "bg-bg-card" : ""
+            }`}
+          >
+            <div className="flex items-center gap-3">
+              <span className="material-symbols-outlined text-base text-text-muted">schedule</span>
+              <div>
+                <div className="text-[11px] font-mono text-text-primary">{scan.timestamp}</div>
+                <div className="text-[9px] font-mono text-text-muted mt-0.5">ID: {scan.id}</div>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] font-mono text-primary font-bold">{scan.signalCount}</span>
+              <span className="text-[9px] font-mono text-text-muted">signals</span>
+              <span className="material-symbols-outlined text-base text-text-muted">chevron_right</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Implement History Page component for Polyscan based on Figma Design System.

## Changes

- **NavBrand.tsx** — POLYSCAN header + v1.0.0 subtitle
- **NavItem.tsx** — Terminal/History/Settings navigation items (active/inactive states)
- **ScanHistoryPanel.tsx** — 600px history panel with 3 mock scan items + CLEAR ALL/EXPORT buttons
- **HistoryPage.tsx** — Main layout: 240px sidebar + 600px history panel + 600px content
- **App.tsx** — Import HistoryPage, route when nav='history'

## Design

- Colors: primary #33ff99, over #ff5f52, muted #6b6580
- Typography: JetBrains Mono 11px, Inter 14px
- Layout: responsive, matches Figma design (1440×900)
- Mock data: 3 scans, 4 signal cards (Bitcoin, ETH, Fed, Trump)

## Testing

- ✅ Build: 0 TypeScript errors
- ✅ Tests: 12/12 pass (100%)
- Code style: matches existing Polyscan components

Closes #28