### PR TITLE
feat: scan history persistence with localStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react"
+import { useState, useCallback } from "react"
 import { ScannerPage } from "./components/ScannerPage"
 import { HistoryPage } from "./components/HistoryPage"
 import { StatsBar } from "./components/StatsBar"
 import { FilterBar } from "./components/FilterBar"
 import { useScan } from "./hooks/useScan"
-import type { FilterDirection } from "./types"
+import { useScanHistory } from "./hooks/useScanHistory"
+import type { FilterDirection, GapResult } from "./types"
 
 type NavItem = "terminal" | "history" | "settings"
 
@@ -18,7 +19,11 @@ export default function App() {
   const [active, setActive] = useState<NavItem>("terminal")
   const [minGap, setMinGap] = useState(0.03)
   const [direction, setDirection] = useState<FilterDirection>("ALL")
-  const { results, isScanning, lastScanAt, totalScanned, error, scan } = useScan(minGap)
+  const { history, addScan, clearAll } = useScanHistory()
+  const onScanComplete = useCallback((results: GapResult[], totalScanned: number) => {
+    addScan(results, totalScanned)
+  }, [addScan])
+  const { results, isScanning, lastScanAt, totalScanned, error, scan } = useScan(minGap, onScanComplete)
   const filtered = results.filter(r => direction === "ALL" ? true : r.direction === direction)
 
   return (
@@ -104,7 +109,7 @@ export default function App() {
 
           {/* Page */}
           {active === "terminal" && <ScannerPage results={filtered} error={error} />}
-          {active === "history" && <HistoryPage />}
+          {active === "history" && <HistoryPage history={history} onClearAll={clearAll} />}
           {active !== "terminal" && active !== "history" && (
             <div className="flex-1 flex items-center justify-center">
               <span className="font-mono text-text-muted text-sm uppercase">Coming Soon \u2014 {active}</span>
@@ -142,7 +147,7 @@ export default function App() {
         {/* Mobile content */}
         <main className="flex-1 pb-16">
           {active === "terminal" && <ScannerPage results={filtered} error={error} />}
-          {active === "history" && <HistoryPage />}
+          {active === "history" && <HistoryPage history={history} onClearAll={clearAll} />}
           {active !== "terminal" && active !== "history" && (
             <div className="flex-1 flex items-center justify-center">
               <span className="font-mono text-text-muted text-sm uppercase">Coming Soon \u2014 {active}</span>

--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -1,44 +1,11 @@
+import { useState } from "react"
 import { ScanHistoryPanel } from "./ScanHistoryPanel"
-import type { GapResult } from "../types"
+import type { GapResult, ScanRecord } from "../types"
 
-const mockSignals: GapResult[] = [
-  {
-    question: "Bitcoin above $100k by March?",
-    slug: "bitcoin-100k-march",
-    yes: 0.542,
-    no: 0.398,
-    sum: 0.940,
-    gap: 0.060,
-    direction: "UNDER",
-  },
-  {
-    question: "ETH flips BTC market cap?",
-    slug: "eth-flips-btc",
-    yes: 0.120,
-    no: 0.845,
-    sum: 0.965,
-    gap: 0.035,
-    direction: "UNDER",
-  },
-  {
-    question: "Fed cuts rates in January?",
-    slug: "fed-cuts-jan",
-    yes: 0.680,
-    no: 0.390,
-    sum: 1.070,
-    gap: 0.070,
-    direction: "OVER",
-  },
-  {
-    question: "Trump wins 2028 election?",
-    slug: "trump-2028",
-    yes: 0.310,
-    no: 0.745,
-    sum: 1.055,
-    gap: 0.055,
-    direction: "OVER",
-  },
-]
+interface Props {
+  history: ScanRecord[]
+  onClearAll: () => void
+}
 
 function SignalHistoryCard({ result }: { result: GapResult }) {
   const isUnder = result.direction === "UNDER"
@@ -56,9 +23,7 @@ function SignalHistoryCard({ result }: { result: GapResult }) {
           {result.question}
         </p>
         <span className={`shrink-0 inline-block px-2 py-0.5 text-[9px] font-mono font-bold uppercase rounded-sm ${
-          isUnder
-            ? "bg-under-bg text-under-text"
-            : "bg-over-bg text-over-text"
+          isUnder ? "bg-under-bg text-under-text" : "bg-over-bg text-over-text"
         }`}>
           {result.direction}
         </span>
@@ -113,32 +78,58 @@ function SignalHistoryCard({ result }: { result: GapResult }) {
   )
 }
 
-export function HistoryPage() {
+export function HistoryPage({ history, onClearAll }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(history[0]?.id ?? null)
+
+  const selected = history.find(s => s.id === selectedId) ?? null
+
   return (
     <div className="flex flex-1 min-h-0">
-      {/* History panel — 600px */}
-      <ScanHistoryPanel />
+      <ScanHistoryPanel
+        history={history}
+        selectedId={selectedId}
+        onSelect={setSelectedId}
+        onClearAll={onClearAll}
+      />
 
       {/* Main content — signal cards */}
       <div className="flex-1 overflow-y-auto">
-        {/* Sub-header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border-default">
-          <div>
-            <h3 className="font-mono text-sm text-text-primary uppercase tracking-widest">Scan Details</h3>
-            <p className="text-[9px] font-mono text-text-muted mt-0.5">2025-01-15 14:32:01 UTC &middot; {mockSignals.length} signals</p>
+        {!selected ? (
+          <div className="flex items-center justify-center h-full">
+            <span className="font-mono text-text-muted text-sm uppercase">
+              {history.length === 0 ? "No history yet — run a scan first" : "Select a scan to view signals"}
+            </span>
           </div>
-          <div className="flex items-center gap-2">
-            <span className="text-[9px] font-mono text-text-muted uppercase">Sort by:</span>
-            <button className="text-[9px] font-mono text-primary uppercase">Gap %</button>
-          </div>
-        </div>
+        ) : (
+          <>
+            {/* Sub-header */}
+            <div className="flex items-center justify-between px-6 py-4 border-b border-border-default">
+              <div>
+                <h3 className="font-mono text-sm text-text-primary uppercase tracking-widest">Scan Details</h3>
+                <p className="text-[9px] font-mono text-text-muted mt-0.5">
+                  {selected.timestamp.toISOString().replace("T", " ").slice(0, 19)} UTC &middot; {selected.results.length} signals
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[9px] font-mono text-text-muted uppercase">Sort by:</span>
+                <button className="text-[9px] font-mono text-primary uppercase">Gap %</button>
+              </div>
+            </div>
 
-        {/* Signal cards grid */}
-        <div className="p-6 grid grid-cols-1 xl:grid-cols-2 gap-4">
-          {mockSignals.map((signal) => (
-            <SignalHistoryCard key={signal.slug} result={signal} />
-          ))}
-        </div>
+            {/* Signal cards grid */}
+            {selected.results.length === 0 ? (
+              <div className="flex items-center justify-center h-40">
+                <span className="font-mono text-text-muted text-sm uppercase">No signals in this scan</span>
+              </div>
+            ) : (
+              <div className="p-6 grid grid-cols-1 xl:grid-cols-2 gap-4">
+                {selected.results.map((signal) => (
+                  <SignalHistoryCard key={signal.slug} result={signal} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/components/ScanHistoryPanel.tsx
+++ b/src/components/ScanHistoryPanel.tsx
@@ -1,57 +1,65 @@
-interface ScanHistoryItem {
-  id: string
-  timestamp: string
-  signalCount: number
+import type { ScanRecord } from "../types"
+
+interface Props {
+  history: ScanRecord[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+  onClearAll: () => void
 }
 
-const mockHistory: ScanHistoryItem[] = [
-  { id: "scan-001", timestamp: "2025-01-15 14:32:01 UTC", signalCount: 12 },
-  { id: "scan-002", timestamp: "2025-01-15 14:28:45 UTC", signalCount: 8 },
-  { id: "scan-003", timestamp: "2025-01-15 14:25:12 UTC", signalCount: 15 },
-]
-
-export function ScanHistoryPanel() {
+export function ScanHistoryPanel({ history, selectedId, onSelect, onClearAll }: Props) {
   return (
     <div className="w-[600px] flex-shrink-0 bg-bg-sidebar border-r border-border-default flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between px-5 py-4 border-b border-border-default">
         <div>
           <h2 className="font-mono text-sm text-text-primary uppercase tracking-widest">Scan History</h2>
-          <p className="text-[9px] font-mono text-text-muted mt-0.5">{mockHistory.length} recent scans</p>
+          <p className="text-[9px] font-mono text-text-muted mt-0.5">{history.length} recent scans</p>
         </div>
         <div className="flex items-center gap-2">
-          <button className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-border-default text-text-muted hover:text-over-text hover:border-over-text transition-colors">
+          <button
+            onClick={onClearAll}
+            className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-border-default text-text-muted hover:text-over-text hover:border-over-text transition-colors"
+          >
             Clear All
-          </button>
-          <button className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-primary text-primary hover:bg-primary hover:text-on-primary transition-colors">
-            Export
           </button>
         </div>
       </div>
 
       {/* Scan list */}
       <div className="flex-1 overflow-y-auto">
-        {mockHistory.map((scan, i) => (
-          <div
-            key={scan.id}
-            className={`flex items-center justify-between px-5 py-3 border-b border-border-default cursor-pointer transition-colors hover:bg-bg-card ${
-              i === 0 ? "bg-bg-card" : ""
-            }`}
-          >
-            <div className="flex items-center gap-3">
-              <span className="material-symbols-outlined text-base text-text-muted">schedule</span>
-              <div>
-                <div className="text-[11px] font-mono text-text-primary">{scan.timestamp}</div>
-                <div className="text-[9px] font-mono text-text-muted mt-0.5">ID: {scan.id}</div>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-[11px] font-mono text-primary font-bold">{scan.signalCount}</span>
-              <span className="text-[9px] font-mono text-text-muted">signals</span>
-              <span className="material-symbols-outlined text-base text-text-muted">chevron_right</span>
-            </div>
+        {history.length === 0 ? (
+          <div className="flex items-center justify-center h-32">
+            <span className="text-[11px] font-mono text-text-muted uppercase">No scans yet — run a scan first</span>
           </div>
-        ))}
+        ) : (
+          history.map((scan) => {
+            const timeStr = scan.timestamp.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" })
+            const dateStr = scan.timestamp.toISOString().slice(0, 10)
+            return (
+              <div
+                key={scan.id}
+                onClick={() => onSelect(scan.id)}
+                className={`flex items-center justify-between px-5 py-3 border-b border-border-default cursor-pointer transition-colors hover:bg-bg-card ${
+                  scan.id === selectedId ? "bg-bg-card" : ""
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="material-symbols-outlined text-base text-text-muted">schedule</span>
+                  <div>
+                    <div className="text-[11px] font-mono text-text-primary">{dateStr} {timeStr} UTC</div>
+                    <div className="text-[9px] font-mono text-text-muted mt-0.5">ID: {scan.id}</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-[11px] font-mono text-primary font-bold">{scan.results.length}</span>
+                  <span className="text-[9px] font-mono text-text-muted">signals</span>
+                  <span className="material-symbols-outlined text-base text-text-muted">chevron_right</span>
+                </div>
+              </div>
+            )
+          })
+        )}
       </div>
     </div>
   )

--- a/src/hooks/useScan.ts
+++ b/src/hooks/useScan.ts
@@ -3,7 +3,7 @@ import { fetchAllMarkets, fetchMidpoints } from "../api/polymarket"
 import { calcGaps } from "../utils/calculator"
 import type { GapResult } from "../types"
 
-export function useScan(minGap: number) {
+export function useScan(minGap: number, onComplete?: (results: GapResult[], totalScanned: number) => void) {
   const [results, setResults] = useState<GapResult[]>([])
   const [isScanning, setIsScanning] = useState(false)
   const [lastScanAt, setLastScanAt] = useState<Date | null>(null)
@@ -18,14 +18,16 @@ export function useScan(minGap: number) {
       setTotalScanned(markets.length)
       const prices = await fetchMidpoints(markets)
       const gaps = calcGaps(markets, prices)
-      setResults(gaps.filter(g => g.gap >= minGap))
+      const filtered = gaps.filter(g => g.gap >= minGap)
+      setResults(filtered)
       setLastScanAt(new Date())
+      onComplete?.(gaps, markets.length)
     } catch (e) {
       setError(e instanceof Error ? e.message : "Scan failed")
     } finally {
       setIsScanning(false)
     }
-  }, [minGap])
+  }, [minGap, onComplete])
 
   return { results, isScanning, lastScanAt, totalScanned, error, scan }
 }

--- a/src/hooks/useScanHistory.ts
+++ b/src/hooks/useScanHistory.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback } from "react"
+import type { GapResult, ScanRecord } from "../types"
+
+const STORAGE_KEY = "polyscan_history"
+const MAX_RECORDS = 50
+
+function loadFromStorage(): ScanRecord[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as Array<Omit<ScanRecord, "timestamp"> & { timestamp: string }>
+    return parsed.map(r => ({ ...r, timestamp: new Date(r.timestamp) }))
+  } catch {
+    return []
+  }
+}
+
+function saveToStorage(records: ScanRecord[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(records))
+  } catch {
+    // storage full — fail silently
+  }
+}
+
+export function useScanHistory() {
+  const [history, setHistory] = useState<ScanRecord[]>(loadFromStorage)
+
+  const addScan = useCallback((results: GapResult[], totalScanned: number) => {
+    const record: ScanRecord = {
+      id: `scan-${Date.now()}`,
+      timestamp: new Date(),
+      totalScanned,
+      results,
+    }
+    setHistory(prev => {
+      const next = [record, ...prev].slice(0, MAX_RECORDS)
+      saveToStorage(next)
+      return next
+    })
+  }, [])
+
+  const clearAll = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY)
+    setHistory([])
+  }, [])
+
+  return { history, addScan, clearAll }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,13 @@ export interface Market {
   active:        boolean
 }
 
+export interface ScanRecord {
+  id: string
+  timestamp: Date
+  totalScanned: number
+  results: GapResult[]
+}
+
 export type FilterDirection = "ALL" | "OVER" | "UNDER"
 
 export type Direction = FilterDirection


### PR DESCRIPTION
Closes #33

## Summary

- **`useScanHistory` hook** — persists scan records to localStorage (max 50), loads on mount, handles corrupt data gracefully
- **`useScan` onComplete callback** — fires after each successful scan with all results (unfiltered) + totalScanned count
- **`App.tsx`** — wires `addScan` as the `onComplete` callback; passes `history` + `clearAll` to `HistoryPage`
- **`ScanHistoryPanel`** — real data: clickable rows, selected state highlight, empty state, Clear All button
- **`HistoryPage`** — shows signal cards for selected scan, defaults to newest scan, proper empty states

## Test plan

- [ ] Run a scan → navigate to History tab → scan appears in list
- [ ] Click a scan row → signal cards update to that scan's results
- [ ] Refresh page → history persists
- [ ] Run multiple scans → newest appears at top
- [ ] Clear All → list empties, localStorage cleared
- [ ] History with 0 scans → shows "No history yet" empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)