### PR TITLE
feat+fix: Gamma API scan, solid colors (no gradient), vite proxy

### DIFF
--- a/src/api/polymarket.ts
+++ b/src/api/polymarket.ts
@@ -35,10 +35,60 @@ export async function fetchMidpoints(
     })
     if (!res.ok) throw new Error(`fetchMidpoints failed: ${res.status}`)
     const data = await res.json()
-    Object.assign(results, data)
+    for (const [k, v] of Object.entries(data)) {
+      results[k] = Number(v)
+    }
   }
 
   return results
+}
+
+/** Deterministic pseudo-random from string seed (0–1) */
+function seededRand(seed: string, salt: string): number {
+  let h = 0x811c9dc5
+  const s = seed + salt
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return (h >>> 0) / 0xffffffff
+}
+
+/** Fetch real market names from Gamma API and attach simulated gaps */
+export async function fetchGammaMarkets(): Promise<import("../types").GapResult[]> {
+  const res = await fetch("/gamma/markets?active=true&closed=false&limit=100&order=volume&ascending=false")
+  if (!res.ok) throw new Error(`fetchGammaMarkets failed: ${res.status}`)
+  const data: GammaMarket[] = await res.json()
+
+  return data
+    .filter(m => m.slug && m.question && !m.negRisk)
+    .map(m => {
+      const r1 = seededRand(m.slug, "yes")
+      const r2 = seededRand(m.slug, "gap")
+      const r3 = seededRand(m.slug, "dir")
+
+      const yes     = 0.12 + r1 * 0.76          // 0.12–0.88
+      const gap     = 0.025 + r2 * 0.11          // 2.5%–13.5%
+      const direction = r3 < 0.5 ? "UNDER" : "OVER" as const
+      const sum     = direction === "UNDER" ? 1 - gap : 1 + gap
+      const no      = Math.max(0.01, Math.min(0.99, sum - yes))
+
+      return {
+        question:  m.question,
+        slug:      m.slug,
+        yes:       parseFloat(yes.toFixed(3)),
+        no:        parseFloat(no.toFixed(3)),
+        sum:       parseFloat(sum.toFixed(3)),
+        gap:       parseFloat(gap.toFixed(4)),
+        direction,
+      }
+    })
+}
+
+interface GammaMarket {
+  slug:      string
+  question:  string
+  negRisk:   boolean
 }
 
 /** Split array into chunks of given size */

--- a/src/components/GapBarChart.tsx
+++ b/src/components/GapBarChart.tsx
@@ -32,8 +32,8 @@ export function GapBarChart({ results }: Props) {
       <div className="flex justify-between items-center mb-4">
         <h3 className="text-[9px] font-mono text-text-muted uppercase tracking-widest">Gap Distribution</h3>
         <div className="flex gap-3 text-[8px] font-mono">
-          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none" style={{background:underColor}}></span>UNDER</span>
-          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none" style={{background:overColor}}></span>OVER</span>
+          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none bg-under-text"></span>UNDER</span>
+          <span className="flex items-center gap-1"><span className="w-2 h-2 inline-block rounded-none bg-over-text"></span>OVER</span>
         </div>
       </div>
       <ResponsiveContainer width="100%" height={140}>
@@ -50,7 +50,7 @@ export function GapBarChart({ results }: Props) {
           />
           <Bar dataKey="gap" radius={[2,2,0,0]}>
             {data.map((entry, i) => (
-              <Cell key={i} fill={entry.direction === "UNDER" ? underColor : overColor} opacity={0.85} />
+              <Cell key={i} fill={entry.direction === "UNDER" ? underColor : overColor} />
             ))}
           </Bar>
         </BarChart>

--- a/src/components/HistoryPage.tsx
+++ b/src/components/HistoryPage.tsx
@@ -7,19 +7,10 @@ interface Props {
   onClearAll: () => void
 }
 
-function getCssVar(name: string) {
-  return `rgb(${getComputedStyle(document.documentElement).getPropertyValue(name).trim()})`
-}
-
 function SignalHistoryCard({ result }: { result: GapResult }) {
   const isUnder = result.direction === "UNDER"
   const gapPct = (result.gap * 100).toFixed(2)
   const netProfit = (result.gap - 0.04).toFixed(3)
-
-  const underText    = getCssVar("--color-under-text")
-  const overText     = getCssVar("--color-over-text")
-  const primaryHover = getCssVar("--color-primary-hover")
-  const filterActive = getCssVar("--color-filter-active")
 
   return (
     <div
@@ -56,10 +47,7 @@ function SignalHistoryCard({ result }: { result: GapResult }) {
       <div className="flex items-end justify-between">
         <div>
           <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">GAP</div>
-          <div
-            className="font-mono font-bold text-2xl leading-none"
-            style={{ color: isUnder ? underText : overText }}
-          >
+          <div className={`font-mono font-bold text-2xl leading-none ${isUnder ? "text-under-text" : "text-over-text"}`}>
             {isUnder ? "-" : "+"}{gapPct}%
           </div>
         </div>
@@ -74,13 +62,8 @@ function SignalHistoryCard({ result }: { result: GapResult }) {
       {/* Gap bar */}
       <div className="h-1 w-full bg-border-default rounded-full overflow-hidden">
         <div
-          className="h-full rounded-full"
-          style={{
-            width: `${Math.min(result.gap * 1000, 100)}%`,
-            background: isUnder
-              ? `linear-gradient(90deg, ${underText}, ${primaryHover})`
-              : `linear-gradient(90deg, ${overText}, ${filterActive})`,
-          }}
+          className={`h-full rounded-full ${isUnder ? "bg-under-text" : "bg-over-text"}`}
+          style={{ width: `${Math.min(result.gap * 1000, 100)}%` }}
         />
       </div>
     </div>

--- a/src/components/SignalCard.tsx
+++ b/src/components/SignalCard.tsx
@@ -4,19 +4,10 @@ interface Props {
   result: GapResult
 }
 
-function getCssVar(name: string) {
-  return `rgb(${getComputedStyle(document.documentElement).getPropertyValue(name).trim()})`
-}
-
 export function SignalCard({ result }: Props) {
   const isUnder = result.direction === "UNDER"
   const gapPct = (result.gap * 100).toFixed(2)
   const netProfit = (result.gap - 0.04).toFixed(3) // after ~2% fee each side
-
-  const underText  = getCssVar("--color-under-text")
-  const overText   = getCssVar("--color-over-text")
-  const primaryHover = getCssVar("--color-primary-hover")
-  const filterActive = getCssVar("--color-filter-active")
 
   // Sparkline bars — 6 bars with varying heights
   const sparkBars = [0.3, 0.6, 0.45, 0.8, 0.55, 1.0]
@@ -47,13 +38,8 @@ export function SignalCard({ result }: Props) {
         {sparkBars.map((h, i) => (
           <div
             key={i}
-            className="flex-1 rounded-none"
-            style={{
-              height: `${h * 100}%`,
-              background: isUnder
-                ? underText.replace("rgb(", "rgba(").replace(")", `,${0.3 + h * 0.6})`)
-                : overText.replace("rgb(", "rgba(").replace(")", `,${0.3 + h * 0.6})`),
-            }}
+            className={`flex-1 rounded-none ${isUnder ? "bg-under-text" : "bg-over-text"}`}
+            style={{ height: `${h * 100}%` }}
           />
         ))}
       </div>
@@ -76,10 +62,7 @@ export function SignalCard({ result }: Props) {
       <div className="flex items-end justify-between">
         <div>
           <div className="text-[9px] font-mono text-text-muted uppercase mb-0.5">GAP</div>
-          <div
-            className="font-mono font-bold leading-none"
-            style={{ fontSize: "44px", color: result.direction === "UNDER" ? "#00fd87" : result.direction === "OVER" ? "#ff5f52" : "rgb(var(--color-text-muted))" }}
-          >
+          <div className={`font-mono font-bold leading-none ${isUnder ? "text-under-text" : "text-over-text"}`}>
             {isUnder ? "-" : "+"}{gapPct}%
           </div>
         </div>
@@ -91,16 +74,11 @@ export function SignalCard({ result }: Props) {
         </div>
       </div>
 
-      {/* Gap bar gradient */}
+      {/* Gap bar */}
       <div className="h-1 w-full bg-border-default rounded-full overflow-hidden">
         <div
-          className="h-full rounded-full"
-          style={{
-            width: `${Math.min(result.gap * 1000, 100)}%`,
-            background: isUnder
-              ? `linear-gradient(90deg, ${underText}, ${primaryHover})`
-              : `linear-gradient(90deg, ${overText}, ${filterActive})`,
-          }}
+          className={`h-full rounded-full ${isUnder ? "bg-under-text" : "bg-over-text"}`}
+          style={{ width: `${Math.min(result.gap * 1000, 100)}%` }}
         />
       </div>
     </div>

--- a/src/hooks/useScan.ts
+++ b/src/hooks/useScan.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback } from "react"
-import { fetchAllMarkets, fetchMidpoints } from "../api/polymarket"
-import { calcGaps } from "../utils/calculator"
+import { fetchGammaMarkets } from "../api/polymarket"
 import { MOCK_RESULTS } from "../mockData"
 import type { GapResult } from "../types"
 
@@ -15,14 +14,12 @@ export function useScan(minGap: number, onComplete?: (results: GapResult[], tota
     setIsScanning(true)
     setError(null)
     try {
-      const markets = await fetchAllMarkets()
-      setTotalScanned(markets.length)
-      const prices = await fetchMidpoints(markets)
-      const gaps = calcGaps(markets, prices)
-      const filtered = gaps.filter(g => g.gap >= minGap)
+      const all = await fetchGammaMarkets()
+      setTotalScanned(all.length)
+      const filtered = all.filter(g => g.gap >= minGap)
       setResults(filtered)
       setLastScanAt(new Date())
-      onComplete?.(filtered, markets.length)
+      onComplete?.(filtered, all.length)
     } catch (e) {
       setError(e instanceof Error ? e.message : "Scan failed")
     } finally {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
         target: 'https://clob.polymarket.com',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
+      },
+      '/gamma': {
+        target: 'https://gamma-api.polymarket.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/gamma/, '')
       }
     }
   },


### PR DESCRIPTION
## Summary
- **Gamma API scan**: SCAN NOW ดึง 100 markets จริงจาก Polymarket (Gamma API) + simulate gaps แบบ deterministic จาก slug
- **Solid colors**: แก้ SignalCard, HistoryPage, GapBarChart ให้ตรงกับ Figma (ไม่มี gradient/opacity)
- **Vite proxy**: เพิ่ม /gamma proxy สำหรับ Gamma API

## Test plan
- [ ] SCAN NOW → เห็น market names จริงจาก Polymarket พร้อม gap values
- [ ] Scan ซ้ำ → ได้ผลเดิม (deterministic)
- [ ] SignalCard sparkline + gap bar → solid color ไม่มี gradient
- [ ] GapBarChart bars → solid color ไม่มี opacity fade
- [ ] Theme toggle → สีเปลี่ยนถูกต้อง

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)