### PR TITLE
feat: Settings page — useSettings hook + SettingsPage component

### DIFF
--- a/TASK_DESIGN.md
+++ b/TASK_DESIGN.md
@@ -1,0 +1,180 @@
+# task-design — Design Workflow Rules
+
+กฎการทำงานออกแบบ (Figma) สำหรับ Polyscan project — ห้ามข้ามขั้นตอน
+
+---
+
+## 8 กฎหลัก (จาก owner)
+
+1. **กำหนด scope ชัดเจน** — ระบุว่ากำลังออกแบบ page/feature อะไร
+2. **Analysis ก่อนออกแบบ** — วิเคราะห์ละเอียดว่าควรมีอะไรบ้าง (UX flows, states, edge cases, data model)
+3. **Reuse design system** — ต้องใช้ components/variables ที่มีอยู่แล้วให้ได้มากที่สุด
+4. **Approve ก่อนทุกการเปลี่ยนแปลงใหญ่** — ห้ามทำเองโดยไม่ขอ
+5. **UX/UI หลักการที่ถูกต้อง** — เข้าใจพฤติกรรมผู้ใช้และผู้พัฒนา
+6. **Sync code ↔ Figma เสมอ** — ถ้าฝั่งใดฝั่งหนึ่งเปลี่ยน อีกฝั่งต้องตามทันที
+7. **Recheck ก่อนเริ่มทุกครั้ง** — ทำ full audit ก่อนเริ่มงานเสมอ ห้ามเชื่อรายงานเก่า
+8. **ก่อน implement ต้องถาม** — แล้วทำตาม dev workflow (Issue → branch → PR)
+
+---
+
+## Pre-Flight Checklist (ก่อนเริ่มทุก design task)
+
+- [ ] **อ่าน TASK_DESIGN.md และ feedback memory ที่เกี่ยวข้อง**
+- [ ] **Recheck Figma state**: ทำ audit ทุก page (Desktop, Mobile, Components)
+  - นับ unbound fills/strokes
+  - ตรวจ component coverage (raw frame ไหนควรเป็น instance)
+  - ตรวจ instance overrides
+- [ ] **Recheck code state**: file ที่เกี่ยวข้องตรงกับ Figma component ปัจจุบันไหม
+- [ ] **รายงานสถานะปัจจุบัน** ก่อนเสนอแผน
+- [ ] **เสนอแผน + รอ approve**
+
+---
+
+## During Design
+
+### Archive ก่อนแก้ทุกครั้ง
+- Duplicate node ที่จะแก้ → ย้ายไป `_archive` page
+- ตั้งชื่อ `[BEFORE] <name> · YYYY-MM-DD`
+- Position ต่อท้าย (maxX/maxY + 80px) — ห้ามทับ
+
+### Variable binding (บังคับ)
+- ทุก fill/stroke ต้อง bind variable จาก "Polyscan Tokens" collection
+- ห้าม hardcode rgb ใน production frames
+- ยกเว้น: 🎨 Design Tokens page (intentional reference)
+
+### Component reuse
+- ก่อนสร้าง component ใหม่ ต้องเช็คว่ามี component คล้ายกันใน 🧩 Components page หรือยัง
+- Component property ต้องครบ (variant, text property, instance swap ตามจำเป็น)
+- ทุก raw frame ที่เป็น UI pattern ซ้ำ → ต้องเป็น component instance
+
+### Naming
+- Frame: `Row: <name>`, `Card: <name>`, `Section: <name>`
+- ห้ามทิ้ง name เป็น `Frame` (default)
+- Component variant: `State=active/inactive`, `Type=toggle/text/segment`, `Variant=default/danger`
+
+---
+
+## After Design
+
+### Verification Pipeline (บังคับทุกขั้น — ห้ามข้าม)
+
+**ขั้น 1 — Structural verification (ทันทีหลังแก้)**
+- [ ] ดึง node tree ของ frame ที่แก้ทั้งหมด — verify hierarchy ถูก
+- [ ] นับ children count ของแต่ละ container — ตรงกับที่คาดไว้ไหม
+- [ ] เช็คว่าทุก node ที่ตั้งใจสร้าง/แก้ มีอยู่จริง (ใช้ id ที่ return จาก script)
+- [ ] เช็ค instance ที่สร้างใหม่: `mainComponent` ตรงไหม, `variantProperties` ตรงไหม
+
+**ขั้น 2 — Visual verification (screenshot)**
+- [ ] Screenshot frame ที่แก้ — ตรวจว่าตรงกับ original/intent
+- [ ] Screenshot frame อื่นที่ใช้ component เดียวกัน — ตรวจว่าไม่พังจากการแก้
+- [ ] เปรียบเทียบ side-by-side กับ archive (`[BEFORE] ...`) ถ้ามี
+- [ ] ตรวจ visual issues:
+  - Text cropping/clipping
+  - Element overlap
+  - ขนาดผิด (เทียบ pixel-by-pixel กับ original)
+  - สีไม่ตรงกับ variable ที่คาดหวัง
+
+**ขั้น 3 — Variable binding audit**
+- [ ] Run audit script ที่ scope ทุก page (ใช้ emoji prefix ให้ถูก)
+- [ ] นับ unbound fills + strokes ของแต่ละ page
+- [ ] ถ้าตัวเลข > 0 → ดู sample → ตัดสินว่า intentional หรือต้องแก้
+- [ ] เทียบกับตัวเลขก่อนเริ่ม task — ต้องลดลงหรือเท่าเดิม (ห้ามเพิ่ม)
+
+**ขั้น 4 — Component property verification**
+- [ ] ทุก component ที่สร้าง/แก้ มี `componentPropertyDefinitions` ตามที่ตั้งใจ
+- [ ] Variant names ถูก format (e.g. `State=active`, `Type=toggle`)
+- [ ] Text properties มี default value ที่เหมาะสม
+- [ ] Instance overrides ที่ตั้งไว้ persist จริง (verify โดยอ่าน text node ของ instance อีกครั้ง)
+
+**ขั้น 5 — Cross-frame consistency**
+- [ ] หาทุก frame ที่ใช้ component ที่แก้ — list ครบไหม
+- [ ] Screenshot ทุก frame เหล่านั้น
+- [ ] Verify ว่า render ถูก ไม่มีกรณี broken inheritance
+- [ ] เทียบ structural consistency ระหว่าง 2 frame (เช่น Desktop Sidebar vs Desktop with History Sidebar — ต้องใช้ component เดียวกัน)
+
+**ขั้น 6 — Code↔Figma sync check**
+- [ ] หา code file ที่ implement component นี้ (เช่น `src/components/<Name>.tsx`)
+- [ ] Verify props/state ของ code ตรงกับ component properties ใน Figma
+- [ ] Verify class/style ของ code ใช้ token ตรงกับ Figma variable
+- [ ] ถ้ามี gap → บันทึกใน report
+
+**ขั้น 7 — Re-audit (last gate)**
+- [ ] Run pre-flight audit script อีกรอบ
+- [ ] เทียบกับตัวเลขก่อนเริ่ม
+- [ ] ห้าม report "เสร็จ" ถ้ายังมี unbound เพิ่มขึ้นจากเดิม
+- [ ] ห้าม report "0 issues" ถ้ายังไม่ run audit script ที่ใช้ page name ถูก
+
+---
+
+### Verification Anti-Cheats (ห้ามทำ)
+
+- ❌ เชื่อว่า `setProperties` ใช้ได้ผลโดยไม่ verify text จริงของ instance
+- ❌ Run audit ด้วย page name ที่ไม่มี emoji prefix แล้วได้ 0 → claim "เสร็จ"
+- ❌ Screenshot แค่ frame ที่แก้ โดยไม่ดู cross-frame impact
+- ❌ Verify โดยอ่านแค่ค่า return จาก script ที่ผ่านมา (script อาจ crash กลางทาง)
+- ❌ Skip "ขั้น 7 re-audit" เพราะ "ก็เพิ่งทำไป"
+
+---
+
+### Reporting Format (บังคับ)
+
+```
+## Summary
+- สิ่งที่แก้: <component/instance/frame> × <จำนวน>
+- Component ที่ได้รับผลกระทบ: <list>
+
+## Verification
+- Structural: <pass/fail + detail>
+- Visual: <pass/fail + screenshot evidence>
+- Variable binding: <before count → after count>
+- Cross-frame: <frame list ที่เช็คแล้ว>
+- Code↔Figma sync: <synced / gap detail>
+
+## Frames ที่ owner ต้องไปตรวจ
+1. <page> → <frame name> — เพื่อตรวจ <จุดที่แก้>
+2. ...
+
+## งานที่ยังเหลือ
+- ...
+
+## Risk / สิ่งที่ไม่แน่ใจ
+- ...
+```
+
+---
+
+## Anti-Patterns (ห้ามทำ)
+
+- ❌ Audit ด้วย page name ผิด (ลืม emoji prefix) แล้วเชื่อผลลัพธ์
+- ❌ รายงาน "0 unbound" หรือ "เสร็จแล้ว" โดยไม่ verify
+- ❌ Detach instance เพื่อแก้ปัญหาเฉพาะหน้า (ทำให้ไม่ sync)
+- ❌ สร้าง component ใหม่ทั้งที่มี component คล้ายกันอยู่แล้ว
+- ❌ แก้ Figma โดยไม่ archive ก่อน
+- ❌ ลงมือแก้โดยไม่รอ approve
+- ❌ ใช้ `setProperties` กับ text property แล้วไม่ verify ว่าเปลี่ยนจริง (ใช้ direct text node update แทน)
+- ❌ Resize ก่อน set sizing modes (resize reset เป็น FIXED)
+- ❌ Set `layoutSizingHorizontal/Vertical = 'FILL'` ก่อน append child
+
+---
+
+## ขั้นตอนมาตรฐาน (Standard Flow)
+
+```
+1. อ่าน rules + memory ที่เกี่ยวข้อง
+   ↓
+2. Recheck current state (Figma + code) — full audit
+   ↓
+3. รายงานสถานะ + เสนอแผน
+   ↓
+4. รอ approve
+   ↓
+5. Archive nodes ที่จะแก้
+   ↓
+6. ทำงานเป็น step ย่อย — verify ทุก step
+   ↓
+7. Final audit + screenshot ทุก frame ที่เกี่ยวข้อง
+   ↓
+8. รายงานผลลัพธ์ + frame ที่ owner ต้องตรวจ
+   ↓
+9. ถ้าจะ implement code → ขออนุญาต → ทำตาม dev workflow (Issue → branch → PR)
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import { useState, useCallback } from "react"
 import { ScannerPage } from "./components/ScannerPage"
 import { HistoryPage } from "./components/HistoryPage"
+import { SettingsPage } from "./components/SettingsPage"
 import { StatsBar } from "./components/StatsBar"
 import { FilterBar } from "./components/FilterBar"
 import { useScan } from "./hooks/useScan"
 import { useScanHistory } from "./hooks/useScanHistory"
 import { useTheme } from "./hooks/useTheme"
+import { useSettings } from "./hooks/useSettings"
 import type { FilterDirection, GapResult } from "./types"
 
 type NavItem = "terminal" | "history" | "settings"
@@ -18,9 +20,10 @@ const navItems = [
 
 export default function App() {
   const [active, setActive] = useState<NavItem>("terminal")
-  const [minGap, setMinGap] = useState(0.03)
-  const [direction, setDirection] = useState<FilterDirection>("ALL")
-  const { toggleTheme, currentTheme } = useTheme()
+  const { settings, update: updateSettings, reset: resetSettings } = useSettings()
+  const [minGap, setMinGap] = useState(settings.minGap)
+  const [direction, setDirection] = useState<FilterDirection>(settings.defaultDirection)
+  const { theme, setTheme, toggleTheme, currentTheme } = useTheme()
   const { history, addScan, clearAll } = useScanHistory()
   const onScanComplete = useCallback((results: GapResult[], totalScanned: number) => {
     addScan(results, totalScanned)
@@ -122,10 +125,12 @@ export default function App() {
           {/* Page */}
           {active === "terminal" && <ScannerPage results={filtered} error={error} />}
           {active === "history" && <HistoryPage history={history} onClearAll={clearAll} />}
-          {active !== "terminal" && active !== "history" && (
-            <div className="flex-1 flex items-center justify-center">
-              <span className="font-mono text-text-muted text-sm uppercase">Coming Soon \u2014 {active}</span>
-            </div>
+          {active === "settings" && (
+            <SettingsPage
+              settings={settings} update={updateSettings} onReset={resetSettings}
+              theme={theme} setTheme={setTheme}
+              history={history} onClearHistory={clearAll}
+            />
           )}
         </main>
       </div>
@@ -179,10 +184,12 @@ export default function App() {
         <main className="flex-1 pb-16">
           {active === "terminal" && <ScannerPage results={filtered} error={error} />}
           {active === "history" && <HistoryPage history={history} onClearAll={clearAll} />}
-          {active !== "terminal" && active !== "history" && (
-            <div className="flex-1 flex items-center justify-center">
-              <span className="font-mono text-text-muted text-sm uppercase">Coming Soon \u2014 {active}</span>
-            </div>
+          {active === "settings" && (
+            <SettingsPage
+              settings={settings} update={updateSettings} onReset={resetSettings}
+              theme={theme} setTheme={setTheme}
+              history={history} onClearHistory={clearAll}
+            />
           )}
         </main>
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,265 @@
+import type { ScanRecord } from "../types"
+import type { ThemeId } from "../hooks/useTheme"
+import type { Settings } from "../hooks/useSettings"
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+function SectionCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-2">
+      <h2 className="text-[9px] font-mono font-bold text-text-muted uppercase tracking-widest px-1">{label}</h2>
+      <div className="bg-bg-card rounded overflow-hidden divide-y divide-border-subtle">{children}</div>
+    </div>
+  )
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 gap-4">
+      <span className="text-sm font-body text-text-secondary shrink-0">{label}</span>
+      <div className="flex items-center">{children}</div>
+    </div>
+  )
+}
+
+function SegGroup({ options, value, onChange }: {
+  options: string[]
+  value: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <div className="flex gap-1">
+      {options.map(opt => (
+        <button key={opt} onClick={() => onChange(opt)}
+          className={`px-2 py-1 text-[9px] font-mono font-bold uppercase rounded-sm transition-colors ${
+            value === opt
+              ? "bg-filter-active text-on-filter"
+              : "bg-bg-card-inner border border-border-default text-text-muted hover:text-text-primary"
+          }`}
+        >{opt}</button>
+      ))}
+    </div>
+  )
+}
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-[9px] font-mono text-text-muted uppercase">{checked ? "ON" : "OFF"}</span>
+      <button onClick={() => onChange(!checked)} aria-pressed={checked}
+        className={`relative w-9 h-5 rounded-full transition-colors ${checked ? "bg-primary" : "bg-bg-card-inner border border-border-default"}`}
+      >
+        <span className={`absolute top-[3px] w-3.5 h-3.5 rounded-full bg-text-primary transition-transform ${
+          checked ? "translate-x-[18px]" : "translate-x-[3px]"
+        }`} />
+      </button>
+    </div>
+  )
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  settings: Settings
+  update: (patch: Partial<Settings>) => void
+  onReset: () => void
+  theme: ThemeId
+  setTheme: (t: ThemeId) => void
+  history: ScanRecord[]
+  onClearHistory: () => void
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SettingsPage({ settings, update, onReset, theme, setTheme, history, onClearHistory }: Props) {
+
+  const exportHistory = () => {
+    let content: string
+    let mime: string
+    let ext: string
+    if (settings.exportFormat === "CSV") {
+      const header = "id,timestamp,totalScanned,question,direction,gap\n"
+      const rows = history.flatMap(scan =>
+        scan.results.map(r =>
+          `${scan.id},${scan.timestamp.toISOString()},${scan.totalScanned},${JSON.stringify(r.question)},${r.direction},${r.gap}`
+        )
+      ).join("\n")
+      content = header + rows
+      mime = "text/csv"
+      ext = "csv"
+    } else {
+      content = JSON.stringify(history, null, 2)
+      mime = "application/json"
+      ext = "json"
+    }
+    const blob = new Blob([content], { type: mime })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `polyscan_history.${ext}`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  const appearance = (
+    <SectionCard label="APPEARANCE">
+      <Row label="Theme">
+        <div className="flex gap-1">
+          {(["default", "binance"] as ThemeId[]).map(t => (
+            <button key={t} onClick={() => setTheme(t)}
+              className={`flex items-center gap-1.5 px-2.5 py-1 text-[9px] font-mono uppercase rounded-sm transition-colors border ${
+                theme === t
+                  ? "border-primary text-text-primary"
+                  : "border-border-default text-text-muted hover:text-text-primary"
+              }`}
+            >
+              <span className="w-1.5 h-1.5 rounded-full bg-primary flex-shrink-0" />
+              {t.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </Row>
+      <Row label="Default View">
+        <SegGroup
+          options={["CARDS", "TABLE"]}
+          value={settings.defaultView}
+          onChange={v => update({ defaultView: v as Settings["defaultView"] })}
+        />
+      </Row>
+    </SectionCard>
+  )
+
+  const scanDefaults = (
+    <SectionCard label="SCAN DEFAULTS">
+      <Row label="Min Gap">
+        <div className="flex items-center gap-3">
+          <input
+            type="range" min="1" max="20" value={Math.round(settings.minGap * 100)}
+            onChange={e => update({ minGap: Number(e.target.value) / 100 })}
+            className="w-28 h-0.5 bg-border-default appearance-none cursor-pointer accent-primary"
+          />
+          <span className="text-[9px] font-mono text-primary w-6 text-right">
+            {Math.round(settings.minGap * 100)}¢
+          </span>
+        </div>
+      </Row>
+      <Row label="Default Direction">
+        <SegGroup
+          options={["ALL", "OVER", "UNDER"]}
+          value={settings.defaultDirection}
+          onChange={v => update({ defaultDirection: v as Settings["defaultDirection"] })}
+        />
+      </Row>
+      <Row label="Market Limit">
+        <SegGroup
+          options={["50", "100", "200"]}
+          value={String(settings.marketLimit)}
+          onChange={v => update({ marketLimit: Number(v) as Settings["marketLimit"] })}
+        />
+      </Row>
+      <Row label="Fee Rate">
+        <span className="text-sm font-mono text-text-primary">
+          {(settings.feeRate * 100).toFixed(1)}<span className="text-text-muted ml-0.5">%</span>
+        </span>
+      </Row>
+    </SectionCard>
+  )
+
+  const autoScan = (
+    <SectionCard label="AUTO-SCAN">
+      <Row label="Auto-Scan">
+        <Toggle checked={settings.autoScan} onChange={v => update({ autoScan: v })} />
+      </Row>
+      <Row label="Interval">
+        <SegGroup
+          options={["30S", "1M", "5M", "10M"]}
+          value={settings.scanInterval.toUpperCase()}
+          onChange={v => update({ scanInterval: v.toLowerCase() as Settings["scanInterval"] })}
+        />
+      </Row>
+      <Row label="Notify on Signals">
+        <Toggle checked={settings.notifyOnSignals} onChange={v => update({ notifyOnSignals: v })} />
+      </Row>
+      <Row label="Min Signals to Notify">
+        <SegGroup
+          options={["1", "3", "5"]}
+          value={String(settings.minSignalsToNotify)}
+          onChange={v => update({ minSignalsToNotify: Number(v) as Settings["minSignalsToNotify"] })}
+        />
+      </Row>
+    </SectionCard>
+  )
+
+  const dataHistory = (
+    <SectionCard label="DATA & HISTORY">
+      <Row label="Max Saved Scans">
+        <SegGroup
+          options={["25", "50", "100"]}
+          value={String(settings.maxSavedScans)}
+          onChange={v => update({ maxSavedScans: Number(v) as Settings["maxSavedScans"] })}
+        />
+      </Row>
+      <Row label="Export Format">
+        <SegGroup
+          options={["JSON", "CSV"]}
+          value={settings.exportFormat}
+          onChange={v => update({ exportFormat: v as Settings["exportFormat"] })}
+        />
+      </Row>
+      <div className="flex gap-3 px-4 py-3">
+        <button onClick={exportHistory}
+          className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-border-default text-text-muted hover:text-text-primary hover:border-text-primary transition-colors"
+        >
+          Export All History
+        </button>
+        <button onClick={onClearHistory}
+          className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-over-text text-over-text hover:bg-over-bg transition-colors"
+        >
+          Clear All History
+        </button>
+      </div>
+    </SectionCard>
+  )
+
+  const about = (
+    <SectionCard label="ABOUT">
+      <Row label="Version"><span className="text-sm font-mono text-text-muted">v1.0.0</span></Row>
+      <Row label="Data Source"><span className="text-sm font-body text-text-secondary">Gamma API</span></Row>
+      <div className="px-4 py-3">
+        <button onClick={onReset}
+          className="px-3 py-1.5 text-[9px] font-mono font-bold uppercase rounded-sm border border-over-text text-over-text hover:bg-over-bg transition-colors"
+        >
+          Reset All Settings
+        </button>
+      </div>
+    </SectionCard>
+  )
+
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      {/* Desktop: 2-column */}
+      <div className="hidden lg:grid grid-cols-2 gap-6 max-w-5xl">
+        <div className="space-y-6">
+          {appearance}
+          {scanDefaults}
+        </div>
+        <div className="space-y-6">
+          {autoScan}
+          {dataHistory}
+          {about}
+        </div>
+      </div>
+
+      {/* Mobile: single column */}
+      <div className="lg:hidden space-y-6">
+        {appearance}
+        {scanDefaults}
+        {autoScan}
+        {dataHistory}
+        {about}
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,61 @@
+import { useState, useCallback } from "react"
+import type { FilterDirection } from "../types"
+
+export interface Settings {
+  defaultView: "CARDS" | "TABLE"
+  minGap: number
+  defaultDirection: FilterDirection
+  marketLimit: 50 | 100 | 200
+  feeRate: number
+  autoScan: boolean
+  scanInterval: "30s" | "1m" | "5m" | "10m"
+  notifyOnSignals: boolean
+  minSignalsToNotify: 1 | 3 | 5
+  maxSavedScans: 25 | 50 | 100
+  exportFormat: "JSON" | "CSV"
+}
+
+const STORAGE_KEY = "polyscan_settings"
+
+export const SETTINGS_DEFAULTS: Settings = {
+  defaultView: "CARDS",
+  minGap: 0.03,
+  defaultDirection: "ALL",
+  marketLimit: 100,
+  feeRate: 0.02,
+  autoScan: false,
+  scanInterval: "1m",
+  notifyOnSignals: false,
+  minSignalsToNotify: 1,
+  maxSavedScans: 50,
+  exportFormat: "JSON",
+}
+
+function load(): Settings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return SETTINGS_DEFAULTS
+    return { ...SETTINGS_DEFAULTS, ...JSON.parse(raw) }
+  } catch {
+    return SETTINGS_DEFAULTS
+  }
+}
+
+export function useSettings() {
+  const [settings, setSettings] = useState<Settings>(load)
+
+  const update = useCallback((patch: Partial<Settings>) => {
+    setSettings(prev => {
+      const next = { ...prev, ...patch }
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(next)) } catch {}
+      return next
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    try { localStorage.removeItem(STORAGE_KEY) } catch {}
+    setSettings(SETTINGS_DEFAULTS)
+  }, [])
+
+  return { settings, update, reset }
+}


### PR DESCRIPTION
## Summary
- `useSettings` hook — localStorage-backed, 11 settings fields, reset support
- `SettingsPage` — 5 sections matching Figma design (APPEARANCE, SCAN DEFAULTS, AUTO-SCAN, DATA & HISTORY, ABOUT)
- Desktop 2-column grid / Mobile single column layout

## Test plan
- [ ] Navigate to SETTINGS tab — page renders (no "Coming Soon")
- [ ] Theme selector switches DEFAULT/BINANCE correctly
- [ ] SegmentButton active state shows `filter-active` (pink/yellow) color
- [ ] Toggle OFF→ON works for Auto-Scan and Notify on Signals
- [ ] Min Gap slider updates value in real time
- [ ] Export All History downloads file in selected format (JSON/CSV)
- [ ] Clear All History clears history state
- [ ] Reset All Settings restores defaults
- [ ] Settings persist on page reload (localStorage)
- [ ] Desktop: 2-column layout, Mobile: single column

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)