### PR TITLE
docs: add design rules from Figma audit findings

### DIFF
--- a/TASK_DESIGN.md
+++ b/TASK_DESIGN.md
@@ -28,7 +28,7 @@
 - [ ] **รายงานสถานะปัจจุบัน** ก่อนเสนอแผน
 - [ ] **เสนอแผน + รอ approve**
 
----
+--
 
 ## During Design
 
@@ -51,6 +51,22 @@
 - Frame: `Row: <name>`, `Card: <name>`, `Section: <name>`
 - ห้ามทิ้ง name เป็น `Frame` (default)
 - Component variant: `State=active/inactive`, `Type=toggle/text/segment`, `Variant=default/danger`
+
+### Layer Naming Audit (บังคับ)
+- ห้ามทิ้ง generic names: `Frame`, `Rectangle`, `Ellipse`, `Group`
+- ต้อง rename ทุก node ให้สื่อ semantic role (e.g. `Status Dot`, `Slider Track`, `Color Block`)
+- `Vector` ใน icon components ยกเว้นได้ (SVG paths)
+- ต้อง scan ทุก page ก่อนรายงาน "เสร็จ"
+
+### Component Property Parity (Desktop ↔ Mobile)
+- Desktop ↔ Mobile component ที่ทำหน้าที่เดียวกันต้องมี property เหมือนกัน
+- เช่น NavItem ต้องมี `Tab` property เหมือน MobileNavItem
+- ถ้าเพิ่ม variant ฝั่งหนึ่ง ต้องเพิ่มอีกฝั่งด้วย
+- Screen naming ต้อง match: `Desktop — X` ↔ `Mobile — X`
+
+### Data Consistency Check (Desktop ↔ Mobile)
+- ข้อมูลใน Desktop ต้องตรงกับ Mobile (ชื่อ, ตัวเลข, badge, variant type)
+- ถ้า swap variant ต้องเช็คว่า data ข้างในตรงกับ variant ที่เลือก
 
 ---
 
@@ -154,6 +170,9 @@
 - ❌ ใช้ `setProperties` กับ text property แล้วไม่ verify ว่าเปลี่ยนจริง (ใช้ direct text node update แทน)
 - ❌ Resize ก่อน set sizing modes (resize reset เป็น FIXED)
 - ❌ Set `layoutSizingHorizontal/Vertical = 'FILL'` ก่อน append child
+- ❌ ทิ้ง leftover instance (e.g. MockButton) ไว้ในไฟล์ — ต้อง cleanup ทุกครั้งที่เจอ
+- ❌ สร้าง component variant โดยไม่มี property ที่จำเป็น (e.g. hardcode icon ใน state variant แทนที่จะมี Tab property)
+- ❌ แก้ overlap / resize section แล้วไม่เช็ค section-to-section overlap ที่อาจเกิดจาก bounds เปลี่ยน
 
 ---
 


### PR DESCRIPTION
## Summary
- เพิ่ม design rules ใหม่ 3 ข้อใน "During Design" section
- เพิ่ม anti-patterns 3 ข้อจาก real issues ที่เจอระหว่าง audit

## Changes
**New Rules:**
- Layer Naming Audit — ห้ามทิ้ง generic names (Frame, Rectangle, Ellipse, Group)
- Component Property Parity — Desktop ↔ Mobile component ต้อง match properties
- Data Consistency Check — ข้อมูล + variant ต้องตรงกันทั้ง 2 platforms

**New Anti-Patterns:**
- ❌ ทิ้ง leftover instance (e.g. MockButton)
- ❌ hardcode icon ใน variant แทนที่จะมี property
- ❌ แก้ overlap แล้วไม่เช็ค section-to-section overlap จาก resize

Closes #45

## Test plan
- [ ] Review ว่า rules สอดคล้องกับ workflow ปัจจุบัน
- [ ] ไม่มี conflict กับ rules เดิม

🤖 Generated with [Claude Code](https://claude.com/claude-code)