### PR TITLE
fix: MEDIUM cleanup — tokens, accessibility, dead vars

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -38,7 +38,6 @@ test.describe("Settings page", () => {
   test("direction filter defaults and toggles", async ({ page }) => {
     const allBtn = page.getByRole("button", { name: "ALL" }).nth(0)
     const overBtn = page.getByRole("button", { name: "OVER" }).nth(0)
-    const underBtn = page.getByRole("button", { name: "UNDER" }).nth(0)
 
     await expect(allBtn).toHaveClass(/bg-filter-active/)
 
@@ -48,7 +47,6 @@ test.describe("Settings page", () => {
   })
 
   test("market limit toggle works", async ({ page }) => {
-    const btn50 = page.getByRole("button", { name: "50" }).first()
     const btn100 = page.getByRole("button", { name: "100" }).first()
     const btn200 = page.getByRole("button", { name: "200" }).first()
 

--- a/src/components/SignalCard.tsx
+++ b/src/components/SignalCard.tsx
@@ -17,13 +17,13 @@ export function SignalCard({ result, variant = "card" }: Props) {
   const isCard = variant === "card"
 
   return (
-    <div
-      className={`bg-bg-card border border-border-default p-4 cursor-pointer hover:border-primary transition-colors space-y-3 focus:outline-none focus:ring-2 focus:ring-primary ${
+    <button
+      type="button"
+      className={`bg-bg-card border border-border-default p-4 cursor-pointer hover:border-primary transition-colors space-y-3 focus:outline-none focus:ring-2 focus:ring-primary text-left w-full ${
         isCard ? "rounded-md shadow-elevation-1" : "rounded-sm"
       }`}
-      role="button" tabIndex={0} aria-label={`View ${result.question}`}
+      aria-label={`View ${result.question}`}
       onClick={() => openPolymarketEvent(result.slug)}
-      onKeyDown={e => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openPolymarketEvent(result.slug) } }}
     >
       {/* Header: question + direction badge */}
       <div className="flex items-start justify-between gap-2">
@@ -87,6 +87,6 @@ export function SignalCard({ result, variant = "card" }: Props) {
           style={{ width: `${Math.min(result.gap * 1000, 100)}%` }}
         />
       </div>
-    </div>
+    </button>
   )
 }

--- a/src/test/components.test.tsx
+++ b/src/test/components.test.tsx
@@ -55,7 +55,6 @@ describe("SignalCard", () => {
     render(<SignalCard result={mockResult} />)
     const card = screen.getByRole("button", { name: /View Will BTC hit \$100k\?/ })
     expect(card).toBeInTheDocument()
-    expect(card).toHaveAttribute("tabindex", "0")
   })
 
   it("renders sparkline in card variant", () => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,25 +33,11 @@ export default {
         "border-default": "rgb(var(--color-border-default) / <alpha-value>)",
         "border-subtle":  "rgb(var(--color-border-subtle) / <alpha-value>)",
 
-        /* Legacy compat */
-        "surface":           "rgb(var(--color-bg-base) / <alpha-value>)",
-        "surface-dim":       "rgb(var(--color-bg-sidebar) / <alpha-value>)",
-        "surface-low":       "rgb(var(--color-bg-card) / <alpha-value>)",
-        "surface-container": "rgb(var(--color-bg-card-inner) / <alpha-value>)",
+        /* Used by direction badge "FAIR" */
         "surface-high":      "rgb(var(--color-border-default) / <alpha-value>)",
-        "surface-highest":   "rgb(var(--color-border-subtle) / <alpha-value>)",
-        "on-surface":        "rgb(var(--color-text-primary) / <alpha-value>)",
-        "on-surface-variant":"rgb(var(--color-text-secondary) / <alpha-value>)",
-        "outline":           "rgb(var(--color-text-muted) / <alpha-value>)",
-        "outline-variant":   "rgb(var(--color-border-default) / <alpha-value>)",
-        "primary-fixed":     "rgb(var(--color-primary) / <alpha-value>)",
-        "primary-dim":       "rgb(var(--color-primary-hover) / <alpha-value>)",
-        "secondary":         "rgb(var(--color-over-text) / <alpha-value>)",
-        "secondary-container":"rgb(var(--color-over-bg) / <alpha-value>)",
       },
       fontFamily: {
         mono: ['"JetBrains Mono"', 'monospace'],
-        sg:   ['"Space Grotesk"', 'sans-serif'],
         body: ['Inter', 'sans-serif'],
       },
       borderRadius: {


### PR DESCRIPTION
Closes #60

## Summary
- **M1.** Remove 13 unused Tailwind legacy tokens (surface-*, outline-*, font-sg), keep `surface-high` which is used
- **M2.** Replace `div[role="button"]` → native `<button>` in SignalCard for better keyboard/screen reader support
- **M3.** Remove unused `underBtn` and `btn50` variables in e2e tests

## Test plan
- [x] 33 unit tests pass
- [x] 93 e2e tests pass (Chromium + Firefox + WebKit)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)